### PR TITLE
fix: Add wgs-cancer-pipeline project to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report something that is broken or incorrect
 labels: ["Bug"]
-projects: ["Clinical-Genomics/108"]
+projects: ["Clinical-Genomics/108", "Clinical-Genomics/109"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: User story
 labels: ["User-Story"]
-projects: ["Clinical-Genomics/108"]
+projects: ["Clinical-Genomics/108", "Clinical-Genomics/109"]
 body:
   - type: textarea
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Initial release of nf-core/oncorefiner, created with the [nf-core](https://nf-co
 - Updated PR template, PR checklist, feature request template, bug report template and issue template chooser [#24](https://github.com/Clinical-Genomics/oncorefiner/pull/24)
 - Updated nf-schema to 2.6.1 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
+- Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
 
 ### `Fixed`
 


### PR DESCRIPTION
### Changed

- Added wgs-cancer-pipeline to list of projects in the issue templates so that issues are automatically added to the board upon creation.