### PR TITLE
fix: add_pr_checklist_comment action to run on PRs from forks

### DIFF
--- a/.github/workflows/add_pr_checklist_comment.yml
+++ b/.github/workflows/add_pr_checklist_comment.yml
@@ -1,11 +1,8 @@
 name: Add PR checklist comment
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
-
-permissions:
-  pull-requests: write
 
 jobs:
   add_pr_checklist_comment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Fixed merge mistake introduced in [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25) [#41](https://github.com/Clinical-Genomics/oncorefiner/pull/41)
 - Added necessary GITHUB_TOKEN permissions for action add_pr_checklist_comment [#42](https://github.com/Clinical-Genomics/oncorefiner/pull/42)
 - Updated all modules and removed deprecated `ch_versions` to implement latest nf-core changes that use the `versions` topic channel to collect software versions [#34](https://github.com/Clinical-Genomics/oncorefiner/pull/34)
+- Fixed settings for `add_pr_checklist_comment` to allow action to run on a PR originated from a fork [#45](https://github.com/Clinical-Genomics/oncorefiner/pull/45)
 
 ### `Dependencies`
 


### PR DESCRIPTION
### Fixed

- Settings for `add_pr_checklist_comment` to allow action to run on a PR originated from a fork:
	- Changed event to `pull_request_target` since this is not subject to any token restrictions.
	- Removed unnecessary token permission settings.