### PR TITLE
fix: Add species parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added parameters documentation [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25)
 - Added pre-commit hook for automatic generation of parameters documentation [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25)
 - Added Nextflow strict syntax compatibility [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
-- Added `species` parameter [#49](https://github.com/Clinical-Genomics/oncorefiner/pull/49)
+
 
 ### Changed
 
@@ -45,6 +45,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added necessary GITHUB_TOKEN permissions for action add_pr_checklist_comment [#42](https://github.com/Clinical-Genomics/oncorefiner/pull/42)
 - Updated all modules and removed deprecated `ch_versions` to implement latest nf-core changes that use the `versions` topic channel to collect software versions [#34](https://github.com/Clinical-Genomics/oncorefiner/pull/34)
 - Fixed settings for `add_pr_checklist_comment` to allow action to run on a PR originated from a fork [#45](https://github.com/Clinical-Genomics/oncorefiner/pull/45)
+- Added `species` parameter to provide information for annotation which was previously hardcoded [#49](https://github.com/Clinical-Genomics/oncorefiner/pull/49)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added parameters documentation [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25)
 - Added pre-commit hook for automatic generation of parameters documentation [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25)
 - Added Nextflow strict syntax compatibility [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
+- Added `species` parameter [#49](https://github.com/Clinical-Genomics/oncorefiner/pull/49)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added pre-commit hook for automatic generation of parameters documentation [#25](https://github.com/Clinical-Genomics/oncorefiner/pull/25)
 - Added Nextflow strict syntax compatibility [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 
-
 ### Changed
 
 - Updated PR template, PR checklist, feature request template, bug report template and issue template chooser [#24](https://github.com/Clinical-Genomics/oncorefiner/pull/24)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,4 +1,4 @@
-# nf-core/oncorefiner pipeline parameters
+# Clinical-Genomics/oncorefiner pipeline parameters
 
 Customizable post-processing and extension layer built on top of Oncoanalyser that adapts its outputs to clinical and operational needs, adds missing analyses, and ensures flexibility for evolving standards while retaining Oncoanalyser robust core
 
@@ -8,7 +8,7 @@ Define where the pipeline should find input data and save output data.
 
 | Parameter | Description | Type | Default | Required | Hidden |
 |-----------|-----------|-----------|-----------|-----------|-----------|
-| `input` | Path to comma-separated file containing information about the samples in the experiment. <details><summary>Help</summary><small>You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/oncorefiner/usage#samplesheet-input).</small></details>| `string` |  | True |  |
+| `input` | Path to comma-separated file containing information about the samples in the experiment. <details><summary>Help</summary><small>You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.</small></details>| `string` |  | True |  |
 | `outdir` | The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. | `string` |  | True |  |
 | `email` | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.</small></details>| `string` |  |  |  |
 | `multiqc_title` | MultiQC report title. Printed as page header, used for filename if not otherwise specified. | `string` |  |  |  |
@@ -19,11 +19,10 @@ Reference genome related files and options required for the workflow.
 
 | Parameter | Description | Type | Default | Required | Hidden |
 |-----------|-----------|-----------|-----------|-----------|-----------|
-| `genome` | Name of iGenomes reference. <details><summary>Help</summary><small>If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`. <br><br>See the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details.</small></details>| `string` |  |  |  |
-| `fasta` | Path to FASTA genome file. <details><summary>Help</summary><small>This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.</small></details>| `string` |  |  |  |
+| `fasta` | Path to FASTA genome file. <details><summary>Help</summary><small>If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.</small></details>| `string` |  |  |  |
 | `fai` | Path to FASTA genome index file. <details><summary>Help</summary><small>If none provided, will be generated automatically from the FASTA reference</small></details>| `string` |  |  |  |
-| `igenomes_ignore` | Do not load the iGenomes reference config. <details><summary>Help</summary><small>Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`.</small></details>| `boolean` |  |  | True |
-| `igenomes_base` | The base path to the igenomes reference files | `string` | s3://ngi-igenomes/igenomes/ |  | True |
+| `genome` | Name of the genome reference. (accepted: `GRCh38`\|`GRCh37`) <details><summary>Help</summary><small>Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.</small></details>| `string` | GRCh38 |  |  |
+| `species` | Species of the reference genome. E.g. `--species homo_sapiens`. (accepted: `homo_sapiens`) | `string` | homo_sapiens |  |  |
 
 ## Annotation options
 
@@ -75,3 +74,11 @@ Less common options for the pipeline, typically set in a config file.
 | `help` | Display the help message. | `['boolean', 'string']` |  |  |  |
 | `help_full` | Display the full detailed help message. | `boolean` |  |  |  |
 | `show_hidden` | Display hidden parameters in the help message (only works when --help or --help_full are provided). | `boolean` |  |  |  |
+
+## Other parameters
+
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `snv_vcf` |  | `string` |  |  |  |
+| `sv_vcf` |  | `string` |  |  |  |
+| `custom_extra_files` |  | `string` |  |  |  |

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params {
     fasta                       = null
     fai                         = null
     genome                      = 'GRCh38'
+    species                     = 'homo_sapiens'
 
     // MultiQC options
     multiqc_config              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -49,14 +49,6 @@
             "fa_icon": "fas fa-dna",
             "description": "Reference genome related files and options required for the workflow.",
             "properties": {
-                "genome": {
-                    "type": "string",
-                    "description": "Name of the genome reference.",
-                    "fa_icon": "fas fa-book",
-                    "help_text": "Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.",
-                    "default": "GRCh38",
-                    "enum": ["GRCh38", "GRCh37"]
-                },
                 "fasta": {
                     "type": "string",
                     "format": "file-path",
@@ -75,6 +67,21 @@
                     "description": "Path to FASTA genome index file.",
                     "pattern": "^\\S+\\.fn?a(sta)?\\.fai$",
                     "fa_icon": "fas fa-file"
+                },
+                "genome": {
+                    "type": "string",
+                    "description": "Name of the genome reference.",
+                    "fa_icon": "fas fa-book",
+                    "help_text": "Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.",
+                    "default": "GRCh38",
+                    "enum": ["GRCh38", "GRCh37"]
+                },
+                "species": {
+                    "type": "string",
+                    "default": "homo_sapiens",
+                    "enum": ["homo_sapiens"],
+                    "description": "Species of the reference genome. E.g. `--species homo_sapiens`.",
+                    "help_text": ""
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -49,6 +49,14 @@
             "fa_icon": "fas fa-dna",
             "description": "Reference genome related files and options required for the workflow.",
             "properties": {
+                "genome": {
+                    "type": "string",
+                    "description": "Name of the genome reference.",
+                    "fa_icon": "fas fa-book",
+                    "help_text": "Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.",
+                    "default": "GRCh38",
+                    "enum": ["GRCh38", "GRCh37"]
+                },
                 "fasta": {
                     "type": "string",
                     "format": "file-path",
@@ -67,14 +75,6 @@
                     "description": "Path to FASTA genome index file.",
                     "pattern": "^\\S+\\.fn?a(sta)?\\.fai$",
                     "fa_icon": "fas fa-file"
-                },
-                "genome": {
-                    "type": "string",
-                    "description": "Name of the genome reference.",
-                    "fa_icon": "fas fa-book",
-                    "help_text": "Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.",
-                    "default": "GRCh38",
-                    "enum": ["GRCh38", "GRCh37"]
                 },
                 "species": {
                     "type": "string",

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -146,7 +146,7 @@ workflow ONCOREFINER {
             ENSEMBLVEP_SNV (
                 ch_vep_snv,
                 params.genome,
-                "homo_sapiens",
+                params.species,
                 params.vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,
@@ -210,7 +210,7 @@ workflow ONCOREFINER {
             ENSEMBLVEP_SV(
                 ch_vep_sv,
                 params.genome,
-                "homo_sapiens",
+                params.species,
                 params.vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/oncorefiner/issues/38.

### Fixed

- Added `species` parameter to provide information for annotation which was previously hardcoded.
- Added `species` parameter to `nextflow.config` with default value `homo_sapiens`.
- Updated nextflow schema. Set parameter to enum with `homo_sapiens` as the only option.
- Updated parameters documentation with pre-commit hook.