### PR TITLE
docs: Update link to Contributing Guidelines in PR checklist

### DIFF
--- a/.github/pr_checklist_comment_body.md
+++ b/.github/pr_checklist_comment_body.md
@@ -2,7 +2,7 @@
 
 - [ ] Fill in description of the PR and link to any relevant issues.
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-- [ ] If you've added a new tool, follow the pipeline conventions in the [contribution docs](https://github.com/nf-core/oncorefiner/tree/master/.github/CONTRIBUTING.md).
+- [ ] If you've added a new tool, follow the pipeline conventions in the [contribution docs](https://github.com/Clinical-Genomics/oncorefiner/tree/dev?tab=contributing-ov-file#readme).
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.
 - [ ] `README.md` is updated (including new tool citations and authors/contributors).

--- a/.github/pr_checklist_comment_body.md
+++ b/.github/pr_checklist_comment_body.md
@@ -2,7 +2,7 @@
 
 - [ ] Fill in description of the PR and link to any relevant issues.
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-- [ ] If you've added a new tool, follow the pipeline conventions in the [contribution docs](https://github.com/Clinical-Genomics/oncorefiner/tree/dev?tab=contributing-ov-file#readme).
+- [ ] If you've added a new tool, follow the pipeline conventions in the [Contributing Guidelines](https://github.com/Clinical-Genomics/oncorefiner/tree/dev?tab=contributing-ov-file#readme).
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.
 - [ ] `README.md` is updated (including new tool citations and authors/contributors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Updated nf-schema to 2.6.1 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
-- Updated link to Contributing Guidelines in the PR checklist to point to the rendered dev version of the document [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
+- Updated link to Contributing Guidelines in the PR checklist to point to the rendered version of the document in `dev` [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Updated nf-schema to 2.6.1 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
+- Updated link to Contributing Guidelines in the PR checklist to point to the rendered dev version of the document [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
 
 ### `Fixed`
 


### PR DESCRIPTION
### Changed

- Updated link to Contributing Guidelines in the PR checklist to point to the rendered version of the document in `dev`.