### PR TITLE
refactor: `PREPARE_REFERENCES`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added `species` parameter to provide information for annotation which was previously hardcoded [#49](https://github.com/Clinical-Genomics/oncorefiner/pull/49)
 - Added settings and moved ungrouped parameters to relevant groups [#50](https://github.com/Clinical-Genomics/oncorefiner/pull/50)
 - Fixed bug in `MULTIQC` input channel that prevented the step from running [#54](https://github.com/Clinical-Genomics/oncorefiner/pull/54)
+- Refactored subworkflow `PREPARE_REFERENCES` to include untar logic and be called in the main workflow, before `ONCOREFINER` [#57](https://github.com/Clinical-Genomics/oncorefiner/pull/57)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added `species` parameter to provide information for annotation which was previously hardcoded [#49](https://github.com/Clinical-Genomics/oncorefiner/pull/49)
 - Added settings and moved ungrouped parameters to relevant groups [#50](https://github.com/Clinical-Genomics/oncorefiner/pull/50)
 - Fixed bug in `MULTIQC` input channel that prevented the step from running [#54](https://github.com/Clinical-Genomics/oncorefiner/pull/54)
-- Refactored subworkflow `PREPARE_REFERENCES` to include untar logic and be called in the main workflow, before `ONCOREFINER` [#57](https://github.com/Clinical-Genomics/oncorefiner/pull/57)
+- Refactored subworkflow `PREPARE_REFERENCES` to include logic for untarring vep cache and be called in the main workflow, before `ONCOREFINER` [#57](https://github.com/Clinical-Genomics/oncorefiner/pull/57)
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -13,9 +13,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { ONCOREFINER  } from './workflows/oncorefiner'
+include { ONCOREFINER             } from './workflows/oncorefiner'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
+include { PREPARE_REFERENCES      } from './subworkflows/local/prepare_references'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE
@@ -33,10 +34,19 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     main:
 
     //
+    // Subworkflow: Prepare reference files
+    //
+
+    PREPARE_REFERENCES (
+        params.vep_cache
+        )
+
+    //
     // WORKFLOW: Run pipeline
     //
     ONCOREFINER (
-        samplesheet
+        samplesheet,
+        PREPARE_REFERENCES.out.vep_resources
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html

--- a/modules/nf-core/vcfanno/main.nf
+++ b/modules/nf-core/vcfanno/main.nf
@@ -11,7 +11,7 @@ process VCFANNO {
     tuple val(meta), path(vcf), path(tbi), path(specific_resources)
     path toml
     path lua
-    path resources 
+    path resources
 
     output:
     tuple val(meta), path("*.vcf.gz")       , emit: vcf

--- a/modules/nf-core/vcfanno/main.nf
+++ b/modules/nf-core/vcfanno/main.nf
@@ -11,7 +11,7 @@ process VCFANNO {
     tuple val(meta), path(vcf), path(tbi), path(specific_resources)
     path toml
     path lua
-    path resources
+    path resources 
 
     output:
     tuple val(meta), path("*.vcf.gz")       , emit: vcf

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -10,17 +10,19 @@ workflow PREPARE_REFERENCES {
         val_vep_cache // channel: [mandatory] [ path(cache) ]
 
     main:
-        vep_resources = channel.empty()
-
         //
         // Prepare vep cache files
         //
 
         if (val_vep_cache) {
             if (val_vep_cache.endsWith("tar.gz")) {
-                ch_vep_resources = UNTAR_VEP_CACHE (channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()).untar.map{ _meta, files -> [files]}.collect()
+                vep_resources = UNTAR_VEP_CACHE(
+                                    channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
+                                    )
+                                    .untar.map{ _meta, files -> [files]}
+                                    .collect()
             } else {
-                ch_vep_resources = channel.fromPath(val_vep_cache).collect()
+                vep_resources = channel.fromPath(val_vep_cache).collect()
             }
         }
 

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -7,7 +7,7 @@ include { UNTAR as UNTAR_VEP_CACHE                           } from '../../modul
 
 workflow PREPARE_REFERENCES {
     take:
-        ch_vep_cache // channel: [mandatory] [ path(cache) ]
+        val_vep_cache // channel: [mandatory] [ path(cache) ]
 
     main:
         vep_resources = channel.empty()
@@ -16,15 +16,13 @@ workflow PREPARE_REFERENCES {
         // Prepare vep cache files
         //
 
-        if (ch_vep_cache) {
-            if (ch_vep_cache.vep_cache.endsWith("tar.gz")) {
-                ch_vep_resources = UNTAR_VEP_CACHE (ch_vep_cache.vep_cache).untar.map{ _meta, files -> [files]}.collect()
+        if (val_vep_cache) {
+            if (val_vep_cache.endsWith("tar.gz")) {
+                ch_vep_resources = UNTAR_VEP_CACHE (channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()).untar.map{ _meta, files -> [files]}.collect()
             } else {
-                ch_vep_resources = channel.fromPath(ch_vep_cache.vep_cache).collect()
+                ch_vep_resources = channel.fromPath(val_vep_cache).collect()
             }
         }
-
-
 
     emit:
         vep_resources

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -7,13 +7,25 @@ include { UNTAR as UNTAR_VEP_CACHE                           } from '../../modul
 
 workflow PREPARE_REFERENCES {
     take:
-        ch_vep_cache                 // channel: [mandatory for annotation] [ path(cache) ]
+        ch_vep_cache // channel: [mandatory] [ path(cache) ]
 
     main:
+        vep_resources = channel.empty()
 
-        // Untar
-        UNTAR_VEP_CACHE (ch_vep_cache)
+        //
+        // Prepare vep cache files
+        //
+
+        if (ch_vep_cache) {
+            if (ch_vep_cache.vep_cache.endsWith("tar.gz")) {
+                ch_vep_resources = UNTAR_VEP_CACHE (ch_vep_cache.vep_cache).untar.map{ _meta, files -> [files]}.collect()
+            } else {
+                ch_vep_resources = channel.fromPath(ch_vep_cache.vep_cache).collect()
+            }
+        }
+
+
 
     emit:
-        vep_resources         = UNTAR_VEP_CACHE.out.untar.map{meta, files -> [files]}.collect()
+        vep_resources
 }

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -43,7 +43,7 @@ workflow ONCOREFINER {
 
     take:
         ch_samplesheet // channel: samplesheet read in from --input
-        ch_vep_cache   // channel: [mandatory] [ path(vep_cache) ]
+        vep_cache      // string: [mandatory] path(vep_cache)
 
     main:
 
@@ -134,7 +134,7 @@ workflow ONCOREFINER {
                 params.genome,
                 params.species,
                 params.vep_cache_version,
-                ch_vep_cache,
+                vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files
             )
@@ -197,7 +197,7 @@ workflow ONCOREFINER {
                 params.genome,
                 params.species,
                 params.vep_cache_version,
-                ch_vep_cache,
+                vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files
             )

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -32,7 +32,6 @@ include { BCFTOOLS_VIEW as CLINICAL_FILTERING_SV   } from '../modules/nf-core/bc
 include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_oncorefiner_pipeline'
-include { PREPARE_REFERENCES     } from '../subworkflows/local/prepare_references'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,6 +43,7 @@ workflow ONCOREFINER {
 
     take:
         ch_samplesheet // channel: samplesheet read in from --input
+        ch_vep_cache   // channel: [mandatory] [ path(vep_cache) ]
 
     main:
 
@@ -59,20 +59,7 @@ workflow ONCOREFINER {
         // Reference files
         ch_genome_fasta         = channel.fromPath(params.fasta).map { it -> [[id:it.simpleName], it] }.collect()
 
-        // File channels for PREPARE_REFERENCES
-        ch_vep_cache_unprocessed     = params.vep_cache           ? channel.fromPath(params.vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
-                                                                : channel.value([[],[]])
-
-        PREPARE_REFERENCES (
-            ch_vep_cache_unprocessed
-        )
-        .set { ch_references }
-
-        // Gather or get from params
-        ch_vep_cache                = ( params.vep_cache && params.vep_cache.endsWith("tar.gz") )  ? ch_references.vep_resources
-                                                                            : ( params.vep_cache    ? channel.fromPath(params.vep_cache).collect() : channel.value([]) )
-
-        //
+                //
         // Read and store paths in the vep_plugin_files file
         //
         ch_vep_extra_files_unsplit  = params.vep_plugin_files ? channel.fromPath(params.vep_plugin_files).collect() : channel.value([])

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -59,7 +59,7 @@ workflow ONCOREFINER {
         // Reference files
         ch_genome_fasta         = channel.fromPath(params.fasta).map { it -> [[id:it.simpleName], it] }.collect()
 
-                //
+        //
         // Read and store paths in the vep_plugin_files file
         //
         ch_vep_extra_files_unsplit  = params.vep_plugin_files ? channel.fromPath(params.vep_plugin_files).collect() : channel.value([])


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/CancerBioInfo/issues/113.

### Changed

- Refactored subworkflow `PREPARE_REFERENCES` to include logic to check if vep cache is untarred or not.

### Fixed

- Moved `PREPARE_REFERENCES` to `CLINICALGENOMICS_ONCOREFINER`, called before `ONCOREFINER`.