### PR TITLE
fix: access parameters in `main.nf` only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Added settings and moved ungrouped parameters to relevant groups [#50](https://github.com/Clinical-Genomics/oncorefiner/pull/50)
 - Fixed bug in `MULTIQC` input channel that prevented the step from running [#54](https://github.com/Clinical-Genomics/oncorefiner/pull/54)
 - Refactored subworkflow `PREPARE_REFERENCES` to include logic for untarring vep cache and be called in the main workflow, before `ONCOREFINER` [#57](https://github.com/Clinical-Genomics/oncorefiner/pull/57)
+- Fixed so that parameters are only accessed in `main.nf` and provided to subsequent workflows as `val_*` [#58](https://github.com/Clinical-Genomics/oncorefiner/pull/58)
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -29,8 +29,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
 
     take:
     samplesheet                 // channel: [mandatory] samplesheet read in from --input
-    val_snv_vcf                 // string:  [optional]  path to input SNV vcf
-    val_sv_vcf                  // string:  [optional]  path to input SV vcf
+    val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
+    val_sv_vcf                  // string:  [optional]  path to input SV vcf file
+    val_genome_fasta            // string:  [optional]  path to genome fasta file
 
 
 
@@ -43,6 +44,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_sv_vcf               = channel.fromPath(val_sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_sv_vcf_tbi           = channel.fromPath(val_sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 
+    // Reference files
+    ch_genome_fasta         = channel.fromPath(val_genome_fasta).map { it -> [[id:it.simpleName], it] }.collect()
+
 
 
     //
@@ -53,7 +57,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_snv_vcf,
         ch_snv_vcf_tbi,
         ch_sv_vcf,
-        ch_sv_vcf_tbi
+        ch_sv_vcf_tbi,
+        ch_genome_fasta
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -88,7 +93,8 @@ workflow {
     CLINICALGENOMICS_ONCOREFINER (
         PIPELINE_INITIALISATION.out.samplesheet,
         params.snv_vcf,
-        params.sv_vcf
+        params.sv_vcf,
+        params.fasta
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -35,6 +35,10 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_genome_fasta            // string:  [optional]  path to genome fasta file
     val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
     val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
+    val_vcfanno_resources       // string:  [optional]  path to file containing paths to vcfanno resources (one per line)
+    val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
+    val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
+    val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
 
 
 
@@ -72,6 +76,17 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     }
 
 
+    // Vcfanno
+    ch_vcfanno_resources = val_vcfanno_resources ? channel.fromPath(val_vcfanno_resources).splitText().map{it -> it.trim()}.collect()
+                                                 : channel.value([])
+    ch_vcfanno_lua       = val_vcfanno_lua       ? channel.fromPath(val_vcfanno_lua).collect()
+                                                 : channel.value([])
+    ch_vcfanno_toml      = val_vcfanno_toml      ? channel.fromPath(val_vcfanno_toml).collect()
+                                                 : channel.value([])
+    ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
+                                                 : []
+
+
 
     //
     // Subworkflow: Prepare reference files
@@ -92,7 +107,11 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_sv_vcf_tbi,
         ch_genome_fasta,
         PREPARE_REFERENCES.out.vep_resources,
-        ch_vep_extra_files
+        ch_vep_extra_files,
+        ch_vcfanno_resources,
+        ch_vcfanno_lua,
+        ch_vcfanno_toml,
+        ch_vcfanno_extra,
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -130,7 +149,11 @@ workflow {
         params.sv_vcf,
         params.fasta,
         params.vep_cache,
-        params.vep_plugin_files
+        params.vep_plugin_files,
+        params.vcfanno_resources,
+        params.vcfanno_lua,
+        params.vcfanno_toml,
+        params.vcfanno_extra,
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -17,7 +17,6 @@ include { ONCOREFINER             } from './workflows/oncorefiner'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PREPARE_REFERENCES      } from './subworkflows/local/prepare_references'
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE

--- a/main.nf
+++ b/main.nf
@@ -31,21 +31,19 @@ workflow CLINICALGENOMICS_ONCOREFINER {
 
     take:
     samplesheet                 // channel: [mandatory] samplesheet read in from --input
-    val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
-    val_sv_vcf                  // string:  [optional]  path to input SV vcf file
     val_genome                  // string:  [optional]  genome assembly (e.g. "GRCh38")
     val_genome_fasta            // string:  [optional]  path to genome fasta file
-    val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
-    val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
-    val_vep_cache_version       // string:  [optional]  version of vep cache to use (e.g. "107")
-    val_vcfanno_resources       // string:  [optional]  path to file containing paths to vcfanno resources (one per line)
-    val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
-    val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
-    val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
+    val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
     val_species                 // string:  [optional]  species (e.g. "homo_sapiens")
+    val_sv_vcf                  // string:  [optional]  path to input SV vcf file
     val_svdb_query_dbs          // string:  [optional]  path to file containing paths to SVDB query databases and additional information (one per line)
-
-
+    val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
+    val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
+    val_vcfanno_resources       // string:  [optional]  path to file containing paths to vcfanno resources (one per line)
+    val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
+    val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
+    val_vep_cache_version       // string:  [optional]  version of vep cache to use (e.g. "107")
+    val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
 
     main:
 
@@ -107,22 +105,21 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     //
     ONCOREFINER (
         samplesheet,
+        ch_genome_fasta,
         ch_snv_vcf,
         ch_snv_vcf_tbi,
+        ch_sv_dbs,
         ch_sv_vcf,
         ch_sv_vcf_tbi,
-        ch_genome_fasta,
+        ch_vcfanno_extra,
+        ch_vcfanno_lua,
+        ch_vcfanno_resources,
+        ch_vcfanno_toml,
         PREPARE_REFERENCES.out.vep_resources,
         ch_vep_extra_files,
-        ch_vcfanno_resources,
-        ch_vcfanno_lua,
-        ch_vcfanno_toml,
-        ch_vcfanno_extra,
-        ch_sv_dbs,
         val_genome,
         val_species,
         val_vep_cache_version
-
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -156,19 +153,19 @@ workflow {
     //
     CLINICALGENOMICS_ONCOREFINER (
         PIPELINE_INITIALISATION.out.samplesheet,
-        params.snv_vcf,
-        params.sv_vcf,
-        params.fasta,
-        params.vep_cache,
-        params.vep_plugin_files,
-        params.vcfanno_resources,
-        params.vcfanno_lua,
-        params.vcfanno_toml,
-        params.vcfanno_extra,
-        params.svdb_query_dbs,
         params.genome,
+        params.fasta,
+        params.snv_vcf,
         params.species,
-        params.vep_cache_version
+        params.sv_vcf,
+        params.svdb_query_dbs,
+        params.vcfanno_extra,
+        params.vcfanno_lua,
+        params.vcfanno_resources,
+        params.vcfanno_toml,
+        params.vep_cache,
+        params.vep_cache_version,
+        params.vep_plugin_files
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -39,8 +39,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
     val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
     val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
-
-
+    val_svdb_query_dbs          // string:  [optional]  path to file containing paths to SVDB query databases and additional information (one per line)
 
 
     main:
@@ -59,7 +58,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_vep_cache_unprocessed     = val_vep_cache           ? channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
                                                            : channel.value([[],[]])
 
-    // Parse paths in the file 'vep_plugin_files' to create ch_vep_extra_files
+    // VEP: Parse paths in the file 'vep_plugin_files' to create ch_vep_extra_files
     ch_vep_extra_files_unsplit  = val_vep_plugin_files ? channel.fromPath(val_vep_plugin_files).collect() : channel.value([])
     if (val_vep_plugin_files) {
         ch_vep_extra_files_unsplit.splitCsv ( header:true )
@@ -76,7 +75,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     }
 
 
-    // Vcfanno
+    // Vcfanno: Initialize channels for vcfanno resources, lua and toml files, and extra files
     ch_vcfanno_resources = val_vcfanno_resources ? channel.fromPath(val_vcfanno_resources).splitText().map{it -> it.trim()}.collect()
                                                  : channel.value([])
     ch_vcfanno_lua       = val_vcfanno_lua       ? channel.fromPath(val_vcfanno_lua).collect()
@@ -86,7 +85,21 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
                                                  : []
 
+    // SVDB: Initialize channel for SVDB query databases
+    ch_sv_dbs            = val_svdb_query_dbs    ? channel.fromPath(val_svdb_query_dbs)
+                                                 : channel.empty()
+    ch_sv_dbs.splitCsv ( header:true )
+            .multiMap { row ->
+                vcf_dbs:  row.filename
+                in_frqs:  row.in_freq_info_key
+                in_occs:  row.in_allele_count_info_key
+                out_frqs: row.out_freq_info_key
+                out_occs: row.out_allele_count_info_key
+            }
+            .set { ch_svdb_dbs }
 
+
+    ch_sv_dbs.dump(tag: 'ch_sv_dbs')
 
     //
     // Subworkflow: Prepare reference files
@@ -112,6 +125,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_vcfanno_lua,
         ch_vcfanno_toml,
         ch_vcfanno_extra,
+        ch_sv_dbs
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -154,6 +168,7 @@ workflow {
         params.vcfanno_lua,
         params.vcfanno_toml,
         params.vcfanno_extra,
+        params.svdb_query_dbs
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -40,11 +40,13 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 
 
+
     //
     // WORKFLOW: Run pipeline
     //
     ONCOREFINER (
-        samplesheet
+        samplesheet,
+        ch_snv_vcf
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -77,7 +79,7 @@ workflow {
     // WORKFLOW: Run main workflow
     //
     CLINICALGENOMICS_ONCOREFINER (
-        PIPELINE_INITIALISATION.out.samplesheet
+        PIPELINE_INITIALISATION.out.samplesheet,
         params.snv_vcf
     )
     //

--- a/main.nf
+++ b/main.nf
@@ -32,6 +32,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
     val_sv_vcf                  // string:  [optional]  path to input SV vcf file
     val_genome_fasta            // string:  [optional]  path to genome fasta file
+    val_vep_cache               // string:  [optional] path to vep cache tar gzip file
 
 
 
@@ -47,6 +48,10 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     // Reference files
     ch_genome_fasta         = channel.fromPath(val_genome_fasta).map { it -> [[id:it.simpleName], it] }.collect()
 
+    // File channels for PREPARE_REFERENCES
+    ch_vep_cache_unprocessed     = val_vep_cache           ? channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
+                                                           : channel.value([[],[]])
+
 
 
     //
@@ -58,7 +63,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_snv_vcf_tbi,
         ch_sv_vcf,
         ch_sv_vcf_tbi,
-        ch_genome_fasta
+        ch_genome_fasta,
+        ch_vep_cache_unprocessed
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -94,7 +100,8 @@ workflow {
         PIPELINE_INITIALISATION.out.samplesheet,
         params.snv_vcf,
         params.sv_vcf,
-        params.fasta
+        params.fasta,
+        params.vep_cache
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -17,6 +17,7 @@ include { ONCOREFINER             } from './workflows/oncorefiner'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PREPARE_REFERENCES      } from './subworkflows/local/prepare_references'
+include { validateInputSamplesheet } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline/main.nf'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE
@@ -40,6 +41,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
     val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
     val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
+    val_species                 // string:  [optional]  species (e.g. "homo_sapiens")
     val_svdb_query_dbs          // string:  [optional]  path to file containing paths to SVDB query databases and additional information (one per line)
 
 
@@ -115,7 +117,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_vcfanno_toml,
         ch_vcfanno_extra,
         ch_sv_dbs,
-        val_genome
+        val_genome,
+        val_species
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -159,7 +162,8 @@ workflow {
         params.vcfanno_toml,
         params.vcfanno_extra,
         params.svdb_query_dbs,
-        params.genome
+        params.genome,
+        params.species
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -37,12 +37,14 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_genome_fasta            // string:  [optional]  path to genome fasta file
     val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
     val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
+    val_vep_cache_version       // string:  [optional]  version of vep cache to use (e.g. "107")
     val_vcfanno_resources       // string:  [optional]  path to file containing paths to vcfanno resources (one per line)
     val_vcfanno_lua             // string:  [optional]  path to vcfanno lua file
     val_vcfanno_toml            // string:  [optional]  path to vcfanno toml file
     val_vcfanno_extra           // string:  [optional]  path to file containing paths to extra files for vcfanno (one per line)
     val_species                 // string:  [optional]  species (e.g. "homo_sapiens")
     val_svdb_query_dbs          // string:  [optional]  path to file containing paths to SVDB query databases and additional information (one per line)
+
 
 
     main:
@@ -118,7 +120,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_vcfanno_extra,
         ch_sv_dbs,
         val_genome,
-        val_species
+        val_species,
+        val_vep_cache_version
+
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -163,7 +167,8 @@ workflow {
         params.vcfanno_extra,
         params.svdb_query_dbs,
         params.genome,
-        params.species
+        params.species,
+        params.vep_cache_version
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -33,18 +33,20 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
     val_sv_vcf                  // string:  [optional]  path to input SV vcf file
     val_genome_fasta            // string:  [optional]  path to genome fasta file
-    val_vep_cache               // string:  [optional] path to vep cache tar gzip file
+    val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
+    val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
 
 
 
 
     main:
 
-    // Initialize input channels
+    // Initialize input channels for oncorefiner
     ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_snv_vcf_tbi          = channel.fromPath(val_snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_sv_vcf               = channel.fromPath(val_sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_sv_vcf_tbi           = channel.fromPath(val_sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+    ch_vep_extra_files      = channel.empty()
 
     // Reference files
     ch_genome_fasta         = channel.fromPath(val_genome_fasta).map { it -> [[id:it.simpleName], it] }.collect()
@@ -52,6 +54,22 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     // File channels for PREPARE_REFERENCES
     ch_vep_cache_unprocessed     = val_vep_cache           ? channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
                                                            : channel.value([[],[]])
+
+    // Parse paths in the file 'vep_plugin_files' to create ch_vep_extra_files
+    ch_vep_extra_files_unsplit  = val_vep_plugin_files ? channel.fromPath(val_vep_plugin_files).collect() : channel.value([])
+    if (val_vep_plugin_files) {
+        ch_vep_extra_files_unsplit.splitCsv ( header:true )
+            .map { row ->
+                def f = file(row.vep_files[0])
+                if(f.isFile() || f.isDirectory()){
+                    return [f]
+                } else {
+                    error("\nVep database file ${f} does not exist.")
+                }
+            }
+            .collect()
+            .set {ch_vep_extra_files}
+    }
 
 
 
@@ -73,7 +91,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_sv_vcf,
         ch_sv_vcf_tbi,
         ch_genome_fasta,
-        PREPARE_REFERENCES.out.vep_resources
+        PREPARE_REFERENCES.out.vep_resources,
+        ch_vep_extra_files
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -110,7 +129,8 @@ workflow {
         params.snv_vcf,
         params.sv_vcf,
         params.fasta,
-        params.vep_cache
+        params.vep_cache,
+        params.vep_plugin_files
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -17,7 +17,7 @@ include { ONCOREFINER             } from './workflows/oncorefiner'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline'
 include { PREPARE_REFERENCES      } from './subworkflows/local/prepare_references'
-include { validateInputSamplesheet } from './subworkflows/local/utils_nfcore_oncorefiner_pipeline/main.nf'
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
 
     // Initialize input channels
     ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+    ch_snv_vcf_tbi          = channel.fromPath(val_snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 
 
 
@@ -46,7 +47,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     //
     ONCOREFINER (
         samplesheet,
-        ch_snv_vcf
+        ch_snv_vcf,
+        ch_snv_vcf_tbi
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html

--- a/main.nf
+++ b/main.nf
@@ -30,6 +30,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     take:
     samplesheet                 // channel: [mandatory] samplesheet read in from --input
     val_snv_vcf                 // string:  [optional]  path to input SNV vcf
+    val_sv_vcf                  // string:  [optional]  path to input SV vcf
 
 
 
@@ -39,6 +40,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     // Initialize input channels
     ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_snv_vcf_tbi          = channel.fromPath(val_snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+    ch_sv_vcf               = channel.fromPath(val_sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+    ch_sv_vcf_tbi           = channel.fromPath(val_sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 
 
 
@@ -48,7 +51,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ONCOREFINER (
         samplesheet,
         ch_snv_vcf,
-        ch_snv_vcf_tbi
+        ch_snv_vcf_tbi,
+        ch_sv_vcf,
+        ch_sv_vcf_tbi
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -82,7 +87,8 @@ workflow {
     //
     CLINICALGENOMICS_ONCOREFINER (
         PIPELINE_INITIALISATION.out.samplesheet,
-        params.snv_vcf
+        params.snv_vcf,
+        params.sv_vcf
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -28,9 +28,17 @@ include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_onco
 workflow CLINICALGENOMICS_ONCOREFINER {
 
     take:
-    samplesheet // channel: samplesheet read in from --input
+    samplesheet                 // channel: [mandatory] samplesheet read in from --input
+    val_snv_vcf                 // string:  [optional]  path to input SNV vcf
+
+
+
 
     main:
+
+    // Initialize input channels
+    ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+
 
     //
     // WORKFLOW: Run pipeline
@@ -70,6 +78,7 @@ workflow {
     //
     CLINICALGENOMICS_ONCOREFINER (
         PIPELINE_INITIALISATION.out.samplesheet
+        params.snv_vcf
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -78,14 +78,15 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     }
 
     // Vcfanno: Initialize channels for vcfanno resources, lua and toml files, and extra files
-    ch_vcfanno_resources = val_vcfanno_resources ? channel.fromPath(val_vcfanno_resources).splitText().map{it -> it.trim()}.collect()
-                                                 : channel.value([])
+    ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
+                                                 : []
     ch_vcfanno_lua       = val_vcfanno_lua       ? channel.fromPath(val_vcfanno_lua).collect()
+                                                 : channel.value([])
+    ch_vcfanno_resources = val_vcfanno_resources ? channel.fromPath(val_vcfanno_resources).splitText().map{it -> it.trim()}.collect()
                                                  : channel.value([])
     ch_vcfanno_toml      = val_vcfanno_toml      ? channel.fromPath(val_vcfanno_toml).collect()
                                                  : channel.value([])
-    ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
-                                                 : []
+
 
     // SVDB: Initialize channel for SVDB query csv file
     ch_sv_dbs            = val_svdb_query_dbs    ? channel.fromPath(val_svdb_query_dbs)

--- a/main.nf
+++ b/main.nf
@@ -32,6 +32,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     samplesheet                 // channel: [mandatory] samplesheet read in from --input
     val_snv_vcf                 // string:  [optional]  path to input SNV vcf file
     val_sv_vcf                  // string:  [optional]  path to input SV vcf file
+    val_genome                  // string:  [optional]  genome assembly (e.g. "GRCh38")
     val_genome_fasta            // string:  [optional]  path to genome fasta file
     val_vep_cache               // string:  [optional]  path to vep cache tar gzip file
     val_vep_plugin_files        // string:  [optional]  path to file containing paths to vep plugin files (one per line)
@@ -113,7 +114,8 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_vcfanno_lua,
         ch_vcfanno_toml,
         ch_vcfanno_extra,
-        ch_sv_dbs
+        ch_sv_dbs,
+        val_genome
     )
     emit:
     multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -156,7 +158,8 @@ workflow {
         params.vcfanno_lua,
         params.vcfanno_toml,
         params.vcfanno_extra,
-        params.svdb_query_dbs
+        params.svdb_query_dbs,
+        params.genome
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -50,6 +50,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_sv_vcf               = channel.fromPath(val_sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_sv_vcf_tbi           = channel.fromPath(val_sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_vep_extra_files      = channel.empty()
+    ch_svdb_dbs             = channel.empty()
 
     // Reference files
     ch_genome_fasta         = channel.fromPath(val_genome_fasta).map { it -> [[id:it.simpleName], it] }.collect()
@@ -74,7 +75,6 @@ workflow CLINICALGENOMICS_ONCOREFINER {
             .set {ch_vep_extra_files}
     }
 
-
     // Vcfanno: Initialize channels for vcfanno resources, lua and toml files, and extra files
     ch_vcfanno_resources = val_vcfanno_resources ? channel.fromPath(val_vcfanno_resources).splitText().map{it -> it.trim()}.collect()
                                                  : channel.value([])
@@ -85,21 +85,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
                                                  : []
 
-    // SVDB: Initialize channel for SVDB query databases
+    // SVDB: Initialize channel for SVDB query csv file
     ch_sv_dbs            = val_svdb_query_dbs    ? channel.fromPath(val_svdb_query_dbs)
                                                  : channel.empty()
-    ch_sv_dbs.splitCsv ( header:true )
-            .multiMap { row ->
-                vcf_dbs:  row.filename
-                in_frqs:  row.in_freq_info_key
-                in_occs:  row.in_allele_count_info_key
-                out_frqs: row.out_freq_info_key
-                out_occs: row.out_allele_count_info_key
-            }
-            .set { ch_svdb_dbs }
-
-
-    ch_sv_dbs.dump(tag: 'ch_sv_dbs')
 
     //
     // Subworkflow: Prepare reference files

--- a/main.nf
+++ b/main.nf
@@ -46,7 +46,20 @@ workflow CLINICALGENOMICS_ONCOREFINER {
 
     main:
 
-    // Initialize input channels for oncorefiner
+    //
+    // Subworkflow: Prepare reference files
+    //
+    ch_vep_cache_unprocessed = val_vep_cache ? channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
+                                             : channel.value([[],[]])
+
+    PREPARE_REFERENCES (
+        params.vep_cache
+        )
+
+    //
+    // WORKFLOW: Run pipeline
+    //
+    // Input channels
     ch_snv_vcf              = channel.fromPath(val_snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_snv_vcf_tbi          = channel.fromPath(val_snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
     ch_sv_vcf               = channel.fromPath(val_sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
@@ -57,11 +70,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     // Reference files
     ch_genome_fasta         = channel.fromPath(val_genome_fasta).map { it -> [[id:it.simpleName], it] }.collect()
 
-    // File channels for PREPARE_REFERENCES
-    ch_vep_cache_unprocessed     = val_vep_cache           ? channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
-                                                           : channel.value([[],[]])
-
-    // VEP: Parse paths in the file 'vep_plugin_files' to create ch_vep_extra_files
+    // Input for VEP
     ch_vep_extra_files_unsplit  = val_vep_plugin_files ? channel.fromPath(val_vep_plugin_files).collect() : channel.value([])
     if (val_vep_plugin_files) {
         ch_vep_extra_files_unsplit.splitCsv ( header:true )
@@ -77,7 +86,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
             .set {ch_vep_extra_files}
     }
 
-    // Vcfanno: Initialize channels for vcfanno resources, lua and toml files, and extra files
+    // Input for Vcfanno
     ch_vcfanno_extra     = val_vcfanno_extra     ? channel.fromPath(val_vcfanno_extra).collect()
                                                  : []
     ch_vcfanno_lua       = val_vcfanno_lua       ? channel.fromPath(val_vcfanno_lua).collect()
@@ -88,21 +97,11 @@ workflow CLINICALGENOMICS_ONCOREFINER {
                                                  : channel.value([])
 
 
-    // SVDB: Initialize channel for SVDB query csv file
+    // Input for SVDB
     ch_sv_dbs            = val_svdb_query_dbs    ? channel.fromPath(val_svdb_query_dbs)
                                                  : channel.empty()
 
-    //
-    // Subworkflow: Prepare reference files
-    //
 
-    PREPARE_REFERENCES (
-        params.vep_cache
-        )
-
-    //
-    // WORKFLOW: Run pipeline
-    //
     ONCOREFINER (
         samplesheet,
         ch_genome_fasta,

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -11,11 +11,13 @@ workflow PREPARE_REFERENCES {
 
     main:
 
-        ch_vep_resources = channel.empty()
+        ch_vep_resources = channel.value([[]])
 
         //
         // Prepare vep cache files
         //
+
+        test = channel.fromPath(val_vep_cache).collect().view()
 
         if (val_vep_cache) {
             if (val_vep_cache.endsWith("tar.gz")) {
@@ -23,12 +25,13 @@ workflow PREPARE_REFERENCES {
                                     channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
                                     )
                                     .untar.map{ _meta, files -> [files]}
-                                    .collect()
+                                    .collect().view()
             } else {
                 ch_vep_resources = channel.fromPath(val_vep_cache).collect()
             }
         }
 
     emit:
-        ch_vep_resources
+
+        vep_resources = ch_vep_resources // channel: [vep_cache_files]
 }

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -17,15 +17,13 @@ workflow PREPARE_REFERENCES {
         // Prepare vep cache files
         //
 
-        test = channel.fromPath(val_vep_cache).collect().view()
-
         if (val_vep_cache) {
             if (val_vep_cache.endsWith("tar.gz")) {
                 ch_vep_resources = UNTAR_VEP_CACHE(
                                     channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
                                     )
                                     .untar.map{ _meta, files -> [files]}
-                                    .collect().view()
+                                    .collect()
             } else {
                 ch_vep_resources = channel.fromPath(val_vep_cache).collect()
             }

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -10,7 +10,6 @@ workflow PREPARE_REFERENCES {
         val_vep_cache // string: [mandatory] path(cache)
 
     main:
-
         ch_vep_resources = channel.value([[]])
 
         //
@@ -30,6 +29,5 @@ workflow PREPARE_REFERENCES {
         }
 
     emit:
-
         vep_resources = ch_vep_resources // channel: [vep_cache_files]
 }

--- a/subworkflows/local/prepare_references.nf
+++ b/subworkflows/local/prepare_references.nf
@@ -7,25 +7,28 @@ include { UNTAR as UNTAR_VEP_CACHE                           } from '../../modul
 
 workflow PREPARE_REFERENCES {
     take:
-        val_vep_cache // channel: [mandatory] [ path(cache) ]
+        val_vep_cache // string: [mandatory] path(cache)
 
     main:
+
+        ch_vep_resources = channel.empty()
+
         //
         // Prepare vep cache files
         //
 
         if (val_vep_cache) {
             if (val_vep_cache.endsWith("tar.gz")) {
-                vep_resources = UNTAR_VEP_CACHE(
+                ch_vep_resources = UNTAR_VEP_CACHE(
                                     channel.fromPath(val_vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
                                     )
                                     .untar.map{ _meta, files -> [files]}
                                     .collect()
             } else {
-                vep_resources = channel.fromPath(val_vep_cache).collect()
+                ch_vep_resources = channel.fromPath(val_vep_cache).collect()
             }
         }
 
     emit:
-        vep_resources
+        ch_vep_resources
 }

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -45,6 +45,7 @@ workflow ONCOREFINER {
     take:
         ch_samplesheet // channel: samplesheet read in from --input
         ch_snv_vcf     // channel: [optional]  path to input SNV vcf
+        ch_snv_vcf_tbi // channel: [optional]  path to input SNV vcf tbi file
 
     main:
 
@@ -53,7 +54,7 @@ workflow ONCOREFINER {
         ch_multiqc_files        = channel.empty()
 
 
-        ch_snv_vcf_tbi          = channel.fromPath(params.snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+
         ch_sv_vcf               = channel.fromPath(params.sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
         ch_sv_vcf_tbi           = channel.fromPath(params.sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -127,15 +127,16 @@ workflow ONCOREFINER {
         if (ch_sv_vcf) {
 
             // SVDB QUERY
-            ch_sv_dbs.splitCsv ( header:true )
-                        .multiMap { row ->
-                            vcf_dbs:  row.filename
-                            in_frqs:  row.in_freq_info_key
-                            in_occs:  row.in_allele_count_info_key
-                            out_frqs: row.out_freq_info_key
-                            out_occs: row.out_allele_count_info_key
-                        }
-                        .set { ch_svdb_dbs }
+            ch_sv_dbs
+                .splitCsv ( header:true )
+                .multiMap { row ->
+                    vcf_dbs:  row.filename
+                    in_frqs:  row.in_freq_info_key
+                    in_occs:  row.in_allele_count_info_key
+                    out_frqs: row.out_freq_info_key
+                    out_occs: row.out_allele_count_info_key
+                }
+                .set { ch_svdb_dbs }
 
             SVDB_QUERY_DB (
                 ch_sv_vcf,

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -42,13 +42,14 @@ include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_onco
 workflow ONCOREFINER {
 
     take:
-        ch_samplesheet  // channel: [mandatory] samplesheet read in from --input
-        ch_snv_vcf      // channel: [optional]  [val(meta), path(vcf)]
-        ch_snv_vcf_tbi  // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_sv_vcf       // channel: [optional]  [val(meta), path(vcf)]
-        ch_sv_vcf_tbi   // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_genome_fasta // channel: [optional]  [val(meta), path(fasta)]
-        ch_vep_cache    // channel: [optional]  [vep_cache_files]
+        ch_samplesheet     // channel: [mandatory] samplesheet read in from --input
+        ch_snv_vcf         // channel: [optional]  [val(meta), path(vcf)]
+        ch_snv_vcf_tbi     // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_sv_vcf          // channel: [optional]  [val(meta), path(vcf)]
+        ch_sv_vcf_tbi      // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_genome_fasta    // channel: [optional]  [val(meta), path(fasta)]
+        ch_vep_cache       // channel: [optional]  [vep_cache_files]
+        ch_vep_extra_files // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
 
     main:
 
@@ -58,24 +59,6 @@ workflow ONCOREFINER {
 
 
 
-        //
-        // Read and store paths in the vep_plugin_files file
-        //
-        ch_vep_extra_files_unsplit  = params.vep_plugin_files ? channel.fromPath(params.vep_plugin_files).collect() : channel.value([])
-        ch_vep_extra_files = channel.empty()
-        if (params.vep_plugin_files) {
-            ch_vep_extra_files_unsplit.splitCsv ( header:true )
-                .map { row ->
-                    def f = file(row.vep_files[0])
-                    if(f.isFile() || f.isDirectory()){
-                        return [f]
-                    } else {
-                        error("\nVep database file ${f} does not exist.")
-                    }
-                }
-                .collect()
-                .set {ch_vep_extra_files}
-        }
 
         // Vcfanno
         ch_vcfanno_resources        = params.vcfanno_resources                  ? channel.fromPath(params.vcfanno_resources).splitText().map{it -> it.trim()}.collect()

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -55,6 +55,7 @@ workflow ONCOREFINER {
         ch_vcfanno_toml      // channel: [optional]  [path(toml_file)]
         ch_vcfanno_extra     // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
         ch_sv_dbs            // channel: [optional]  [path(csv)]
+        val_genome           // string:  [optional]  genome assembly (e.g. "GRCh38")
 
     main:
 
@@ -100,7 +101,7 @@ workflow ONCOREFINER {
 
             ENSEMBLVEP_SNV (
                 ch_vep_snv,
-                params.genome,
+                val_genome,
                 params.species,
                 params.vep_cache_version,
                 ch_vep_cache,
@@ -162,7 +163,7 @@ workflow ONCOREFINER {
 
             ENSEMBLVEP_SV(
                 ch_vep_sv,
-                params.genome,
+                val_genome,
                 params.species,
                 params.vep_cache_version,
                 ch_vep_cache,

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -51,7 +51,7 @@ workflow ONCOREFINER {
         ch_versions             = channel.empty()
         ch_multiqc_files        = channel.empty()
 
-        ch_snv_vcf              = channel.fromPath(params.snv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
+
         ch_snv_vcf_tbi          = channel.fromPath(params.snv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
         ch_sv_vcf               = channel.fromPath(params.sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
         ch_sv_vcf_tbi           = channel.fromPath(params.sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -49,6 +49,7 @@ workflow ONCOREFINER {
         ch_sv_vcf       // channel: [optional]  path to input SV vcf file
         ch_sv_vcf_tbi   // channel: [optional]  path to input SV vcf tbi file
         ch_genome_fasta // channel: [optional]  path to genome fasta file
+        ch_vep_cache_unprocessed //channel: [optional] path to vep cache tar gzip file
 
     main:
 
@@ -58,10 +59,6 @@ workflow ONCOREFINER {
 
 
 
-
-        // File channels for PREPARE_REFERENCES
-        ch_vep_cache_unprocessed     = params.vep_cache           ? channel.fromPath(params.vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()
-                                                                : channel.value([[],[]])
 
         PREPARE_REFERENCES (
             ch_vep_cache_unprocessed

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -56,6 +56,7 @@ workflow ONCOREFINER {
         ch_vcfanno_extra     // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
         ch_sv_dbs            // channel: [optional]  [path(csv)]
         val_genome           // string:  [optional]  genome assembly (e.g. "GRCh38")
+        val_species          // string:  [optional]  species (e.g. "homo_sapiens")
 
     main:
 
@@ -102,7 +103,7 @@ workflow ONCOREFINER {
             ENSEMBLVEP_SNV (
                 ch_vep_snv,
                 val_genome,
-                params.species,
+                val_species,
                 params.vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,
@@ -164,7 +165,7 @@ workflow ONCOREFINER {
             ENSEMBLVEP_SV(
                 ch_vep_sv,
                 val_genome,
-                params.species,
+                val_species,
                 params.vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -42,21 +42,23 @@ include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_onco
 workflow ONCOREFINER {
 
     take:
-        ch_samplesheet       // channel: [mandatory] samplesheet read in from --input
-        ch_snv_vcf           // channel: [optional]  [val(meta), path(vcf)]
-        ch_snv_vcf_tbi       // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_sv_vcf            // channel: [optional]  [val(meta), path(vcf)]
-        ch_sv_vcf_tbi        // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_genome_fasta      // channel: [optional]  [val(meta), path(fasta)]
-        ch_vep_cache         // channel: [optional]  [vep_cache_files]
-        ch_vep_extra_files   // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
-        ch_vcfanno_resources // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
-        ch_vcfanno_lua       // channel: [optional]  [path(lua_file)]
-        ch_vcfanno_toml      // channel: [optional]  [path(toml_file)]
-        ch_vcfanno_extra     // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
-        ch_sv_dbs            // channel: [optional]  [path(csv)]
-        val_genome           // string:  [optional]  genome assembly (e.g. "GRCh38")
-        val_species          // string:  [optional]  species (e.g. "homo_sapiens")
+        ch_samplesheet        // channel: [mandatory] samplesheet read in from --input
+        ch_snv_vcf            // channel: [optional]  [val(meta), path(vcf)]
+        ch_snv_vcf_tbi        // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_sv_vcf             // channel: [optional]  [val(meta), path(vcf)]
+        ch_sv_vcf_tbi         // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_genome_fasta       // channel: [optional]  [val(meta), path(fasta)]
+        ch_vep_cache          // channel: [optional]  [vep_cache_files]
+        ch_vep_extra_files    // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
+        ch_vcfanno_resources  // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
+        ch_vcfanno_lua        // channel: [optional]  [path(lua_file)]
+        ch_vcfanno_toml       // channel: [optional]  [path(toml_file)]
+        ch_vcfanno_extra      // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
+        ch_sv_dbs             // channel: [optional]  [path(csv)]
+        val_genome            // string:  [optional]  genome assembly (e.g. "GRCh38")
+        val_species           // string:  [optional]  species (e.g. "homo_sapiens")
+        val_vep_cache_version // string:  [optional]  version of vep cache to use (e.g. "107")
+
 
     main:
 
@@ -104,7 +106,7 @@ workflow ONCOREFINER {
                 ch_vep_snv,
                 val_genome,
                 val_species,
-                params.vep_cache_version,
+                val_vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files
@@ -166,7 +168,7 @@ workflow ONCOREFINER {
                 ch_vep_sv,
                 val_genome,
                 val_species,
-                params.vep_cache_version,
+                val_vep_cache_version,
                 ch_vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -43,22 +43,21 @@ workflow ONCOREFINER {
 
     take:
         ch_samplesheet        // channel: [mandatory] samplesheet read in from --input
+        ch_genome_fasta       // channel: [optional]  [val(meta), path(fasta)]
         ch_snv_vcf            // channel: [optional]  [val(meta), path(vcf)]
         ch_snv_vcf_tbi        // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_sv_dbs             // channel: [optional]  [path(csv)]
         ch_sv_vcf             // channel: [optional]  [val(meta), path(vcf)]
         ch_sv_vcf_tbi         // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_genome_fasta       // channel: [optional]  [val(meta), path(fasta)]
+        ch_vcfanno_extra      // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
+        ch_vcfanno_lua        // channel: [optional]  [path(lua_file)]
+        ch_vcfanno_resources  // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
+        ch_vcfanno_toml       // channel: [optional]  [path(toml_file)]
         ch_vep_cache          // channel: [optional]  [vep_cache_files]
         ch_vep_extra_files    // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
-        ch_vcfanno_resources  // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
-        ch_vcfanno_lua        // channel: [optional]  [path(lua_file)]
-        ch_vcfanno_toml       // channel: [optional]  [path(toml_file)]
-        ch_vcfanno_extra      // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
-        ch_sv_dbs             // channel: [optional]  [path(csv)]
         val_genome            // string:  [optional]  genome assembly (e.g. "GRCh38")
         val_species           // string:  [optional]  species (e.g. "homo_sapiens")
         val_vep_cache_version // string:  [optional]  version of vep cache to use (e.g. "107")
-
 
     main:
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -54,7 +54,7 @@ workflow ONCOREFINER {
         ch_vcfanno_lua       // channel: [optional]  [path(lua_file)]
         ch_vcfanno_toml      // channel: [optional]  [path(toml_file)]
         ch_vcfanno_extra     // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
-        ch_sv_dbs            // channel: [optional]  [path(svdb_query_db1), path(svdb_query_db2), ...]
+        ch_sv_dbs            // channel: [optional]  [path(csv)]
 
     main:
 
@@ -124,7 +124,15 @@ workflow ONCOREFINER {
         if (ch_sv_vcf) {
 
             // SVDB QUERY
-
+            ch_sv_dbs.splitCsv ( header:true )
+                        .multiMap { row ->
+                            vcf_dbs:  row.filename
+                            in_frqs:  row.in_freq_info_key
+                            in_occs:  row.in_allele_count_info_key
+                            out_frqs: row.out_freq_info_key
+                            out_occs: row.out_allele_count_info_key
+                        }
+                        .set { ch_svdb_dbs }
 
             SVDB_QUERY_DB (
                 ch_sv_vcf,

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -50,6 +50,10 @@ workflow ONCOREFINER {
         ch_genome_fasta    // channel: [optional]  [val(meta), path(fasta)]
         ch_vep_cache       // channel: [optional]  [vep_cache_files]
         ch_vep_extra_files // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
+        ch_vcfanno_resources // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
+        ch_vcfanno_lua     // channel: [optional]  [path(lua_file)]
+        ch_vcfanno_toml    // channel: [optional]  [path(toml_file)]
+        ch_vcfanno_extra   // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
 
     main:
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -43,12 +43,12 @@ workflow ONCOREFINER {
 
     take:
         ch_samplesheet  // channel: [mandatory] samplesheet read in from --input
-        ch_snv_vcf      // channel: [optional]  path to input SNV vcf file
-        ch_snv_vcf_tbi  // channel: [optional]  path to input SNV vcf tbi file
-        ch_sv_vcf       // channel: [optional]  path to input SV vcf file
-        ch_sv_vcf_tbi   // channel: [optional]  path to input SV vcf tbi file
-        ch_genome_fasta // channel: [optional]  path to genome fasta file
-        ch_vep_cache    // channel: [mandatory] [vep_cache_files]
+        ch_snv_vcf      // channel: [optional]  [val(meta), path(vcf)]
+        ch_snv_vcf_tbi  // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_sv_vcf       // channel: [optional]  [val(meta), path(vcf)]
+        ch_sv_vcf_tbi   // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_genome_fasta // channel: [optional]  [val(meta), path(fasta)]
+        ch_vep_cache    // channel: [optional]  [vep_cache_files]
 
     main:
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -48,7 +48,7 @@ workflow ONCOREFINER {
         ch_sv_vcf       // channel: [optional]  path to input SV vcf file
         ch_sv_vcf_tbi   // channel: [optional]  path to input SV vcf tbi file
         ch_genome_fasta // channel: [optional]  path to genome fasta file
-        vep_cache       // string: [mandatory] path(vep_cache)
+        ch_vep_cache    // channel: [mandatory] [vep_cache_files]
 
     main:
 
@@ -133,7 +133,7 @@ workflow ONCOREFINER {
                 params.genome,
                 params.species,
                 params.vep_cache_version,
-                vep_cache,
+                ch_vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files
             )
@@ -196,7 +196,7 @@ workflow ONCOREFINER {
                 params.genome,
                 params.species,
                 params.vep_cache_version,
-                vep_cache,
+                ch_vep_cache,
                 ch_genome_fasta,
                 ch_vep_extra_files
             )

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -44,6 +44,7 @@ workflow ONCOREFINER {
 
     take:
         ch_samplesheet // channel: samplesheet read in from --input
+        ch_snv_vcf     // channel: [optional]  path to input SNV vcf
 
     main:
 
@@ -112,7 +113,7 @@ workflow ONCOREFINER {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
         // Process SNV VCF files
-        if (params.snv_vcf) {
+        if (ch_snv_vcf) {
 
             // Vcfanno
             ch_snv_vcf

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -42,29 +42,25 @@ include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_onco
 workflow ONCOREFINER {
 
     take:
-        ch_samplesheet     // channel: [mandatory] samplesheet read in from --input
-        ch_snv_vcf         // channel: [optional]  [val(meta), path(vcf)]
-        ch_snv_vcf_tbi     // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_sv_vcf          // channel: [optional]  [val(meta), path(vcf)]
-        ch_sv_vcf_tbi      // channel: [optional]  [val(meta), path(vcf.tbi)]
-        ch_genome_fasta    // channel: [optional]  [val(meta), path(fasta)]
-        ch_vep_cache       // channel: [optional]  [vep_cache_files]
-        ch_vep_extra_files // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
+        ch_samplesheet       // channel: [mandatory] samplesheet read in from --input
+        ch_snv_vcf           // channel: [optional]  [val(meta), path(vcf)]
+        ch_snv_vcf_tbi       // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_sv_vcf            // channel: [optional]  [val(meta), path(vcf)]
+        ch_sv_vcf_tbi        // channel: [optional]  [val(meta), path(vcf.tbi)]
+        ch_genome_fasta      // channel: [optional]  [val(meta), path(fasta)]
+        ch_vep_cache         // channel: [optional]  [vep_cache_files]
+        ch_vep_extra_files   // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
         ch_vcfanno_resources // channel: [optional]  [path(resource_file1), path(resource_file2), ...]
-        ch_vcfanno_lua     // channel: [optional]  [path(lua_file)]
-        ch_vcfanno_toml    // channel: [optional]  [path(toml_file)]
-        ch_vcfanno_extra   // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
+        ch_vcfanno_lua       // channel: [optional]  [path(lua_file)]
+        ch_vcfanno_toml      // channel: [optional]  [path(toml_file)]
+        ch_vcfanno_extra     // channel: [optional]  [path(extra_file1), path(extra_file2), ...]
+        ch_sv_dbs            // channel: [optional]  [path(svdb_query_db1), path(svdb_query_db2), ...]
 
     main:
 
         // Initialize input channels
         ch_versions             = channel.empty()
         ch_multiqc_files        = channel.empty()
-
-        // SVDB
-        ch_sv_dbs                   = params.svdb_query_dbs                  ? channel.fromPath(params.svdb_query_dbs)
-                                                                            : channel.empty()
-
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -128,16 +124,7 @@ workflow ONCOREFINER {
         if (ch_sv_vcf) {
 
             // SVDB QUERY
-            ch_sv_dbs
-                .splitCsv ( header:true )
-                .multiMap { row ->
-                    vcf_dbs:  row.filename
-                    in_frqs:  row.in_freq_info_key
-                    in_occs:  row.in_allele_count_info_key
-                    out_frqs: row.out_freq_info_key
-                    out_occs: row.out_allele_count_info_key
-                }
-                .set { ch_svdb_dbs }
+
 
             SVDB_QUERY_DB (
                 ch_sv_vcf,

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -46,17 +46,14 @@ workflow ONCOREFINER {
         ch_samplesheet // channel: samplesheet read in from --input
         ch_snv_vcf     // channel: [optional]  path to input SNV vcf
         ch_snv_vcf_tbi // channel: [optional]  path to input SNV vcf tbi file
+        ch_sv_vcf      // channel: [optional]  path to input SV vcf
+        ch_sv_vcf_tbi  // channel: [optional]  path to input SV vcf tbi file
 
     main:
 
         // Initialize input channels
         ch_versions             = channel.empty()
         ch_multiqc_files        = channel.empty()
-
-
-
-        ch_sv_vcf               = channel.fromPath(params.sv_vcf).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
-        ch_sv_vcf_tbi           = channel.fromPath(params.sv_vcf + '.tbi', checkIfExists: true).map { vcf -> [[id:vcf.simpleName], vcf] }.collect()
 
         // Reference files
         ch_genome_fasta         = channel.fromPath(params.fasta).map { it -> [[id:it.simpleName], it] }.collect()
@@ -167,7 +164,7 @@ workflow ONCOREFINER {
         }
 
         // Process SV VCF files
-        if (params.sv_vcf) {
+        if (ch_sv_vcf) {
 
             // SVDB QUERY
             ch_sv_dbs

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -57,19 +57,6 @@ workflow ONCOREFINER {
         ch_versions             = channel.empty()
         ch_multiqc_files        = channel.empty()
 
-
-
-
-        // Vcfanno
-        ch_vcfanno_resources        = params.vcfanno_resources                  ? channel.fromPath(params.vcfanno_resources).splitText().map{it -> it.trim()}.collect()
-                                                                                : channel.value([])
-        ch_vcfanno_lua              = params.vcfanno_lua                        ? channel.fromPath(params.vcfanno_lua).collect()
-                                                                                : channel.value([])
-        ch_vcfanno_toml             = params.vcfanno_toml                       ? channel.fromPath(params.vcfanno_toml).collect()
-                                                                                : channel.value([])
-        ch_vcfanno_extra            = params.vcfanno_extra                      ? channel.fromPath(params.vcfanno_extra).collect()
-                                                                                : []
-
         // SVDB
         ch_sv_dbs                   = params.svdb_query_dbs                  ? channel.fromPath(params.svdb_query_dbs)
                                                                             : channel.empty()

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -43,11 +43,12 @@ include { PREPARE_REFERENCES     } from '../subworkflows/local/prepare_reference
 workflow ONCOREFINER {
 
     take:
-        ch_samplesheet // channel: samplesheet read in from --input
-        ch_snv_vcf     // channel: [optional]  path to input SNV vcf
-        ch_snv_vcf_tbi // channel: [optional]  path to input SNV vcf tbi file
-        ch_sv_vcf      // channel: [optional]  path to input SV vcf
-        ch_sv_vcf_tbi  // channel: [optional]  path to input SV vcf tbi file
+        ch_samplesheet  // channel: [mandatory] samplesheet read in from --input
+        ch_snv_vcf      // channel: [optional]  path to input SNV vcf file
+        ch_snv_vcf_tbi  // channel: [optional]  path to input SNV vcf tbi file
+        ch_sv_vcf       // channel: [optional]  path to input SV vcf file
+        ch_sv_vcf_tbi   // channel: [optional]  path to input SV vcf tbi file
+        ch_genome_fasta // channel: [optional]  path to genome fasta file
 
     main:
 
@@ -55,8 +56,8 @@ workflow ONCOREFINER {
         ch_versions             = channel.empty()
         ch_multiqc_files        = channel.empty()
 
-        // Reference files
-        ch_genome_fasta         = channel.fromPath(params.fasta).map { it -> [[id:it.simpleName], it] }.collect()
+
+
 
         // File channels for PREPARE_REFERENCES
         ch_vep_cache_unprocessed     = params.vep_cache           ? channel.fromPath(params.vep_cache).map { it -> [[id:'vep_cache'], it] }.collect()


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/CancerBioInfo/issues/106

### Changed

- Moved initialisation of input channels to `main.nf`.

### Fixed

- Access parameters in the main workflow only and provide values to the subsequent workflows.
- Bug with input and output for `PREPARE_REFERENCES`:
	- Change name of output variable to reflect the channel variable type.
	- Update type comments.
