### PR TITLE
test: Update `pipelines_testdata_base_path` and paths to test vcf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
 - Updated link to Contributing Guidelines in the PR checklist to point to the rendered version of the document in `dev` [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
-- Updated `pipelines_testdata_base_path` to point to latest commit in `Clinical-Genomics/test-datasets/` [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
-- Updated paths to test vcf files [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
+- Updated `pipelines_testdata_base_path` paths to test vcf files [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
 - Updated link to Contributing Guidelines in the PR checklist to point to the rendered version of the document in `dev` [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
-- Updated `pipelines_testdata_base_path` paths to test vcf files [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
+- Updated `pipelines_testdata_base_path` and paths to test vcf files [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - Updated minimum Nextflow version to 25.10.0 [#30](https://github.com/Clinical-Genomics/oncorefiner/pull/30)
 - Added wgs-cancer-pipeline projects list in the issue templates [#37](https://github.com/Clinical-Genomics/oncorefiner/pull/37)
 - Updated link to Contributing Guidelines in the PR checklist to point to the rendered version of the document in `dev` [#56](https://github.com/Clinical-Genomics/oncorefiner/pull/56)
+- Updated `pipelines_testdata_base_path` to point to latest commit in `Clinical-Genomics/test-datasets/` [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
+- Updated paths to test vcf files [#71](https://github.com/Clinical-Genomics/oncorefiner/pull/71)
 
 ### `Fixed`
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -29,8 +29,8 @@ params {
 
 
     input               = params.pipelines_testdata_base_path + 'testdata/samplesheet_test.csv'
-    snv_vcf             = params.pipelines_testdata_base_path + 'testdata/SNV.tumor.pave.somatic.37.vcf.gz'
-    sv_vcf              = params.pipelines_testdata_base_path + 'testdata/SV.tumor.esvee.somatic.37.vcf.gz'
+    snv_vcf             = params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.somatic.vcf.gz'
+    sv_vcf              = params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz'
     bam_normal          = params.pipelines_testdata_base_path + 'testdata/subject_a.normal.redux.bam'
     bai_normal          = params.pipelines_testdata_base_path + 'testdata/subject_a.normal.redux.bam.bai'
     bam_tumor           = params.pipelines_testdata_base_path + 'testdata/subject_a.tumor.redux.bam'

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -76,7 +76,7 @@ Less common options for the pipeline, typically set in a config file.
 | `multiqc_logo` | Custom logo file to supply to MultiQC. File name must also be set in the MultiQC config file | `string` |  |  | True |
 | `multiqc_methods_description` | Custom MultiQC yaml file containing HTML including a methods description. | `string` |  |  |  |
 | `validate_params` | Boolean whether to validate parameters against the schema at runtime | `boolean` | True |  | True |
-| `pipelines_testdata_base_path` | Base URL or local path to location of pipeline test dataset files | `string` | https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/bc94db3a30d6194f4cebcb9480bf24b0600b4d23/ |  | True |
+| `pipelines_testdata_base_path` | Base URL or local path to location of pipeline test dataset files | `string` | https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/ |  | True |
 | `trace_report_suffix` | Suffix to add to the trace report filename. Default is the date and time in the format yyyy-MM-dd_HH-mm-ss. | `string` |  |  | True |
 | `help` | Display the help message. | `['boolean', 'string']` |  |  |  |
 | `help_full` | Display the full detailed help message. | `boolean` |  |  |  |

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     help_full                    = false
     show_hidden                  = false
     version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/bc94db3a30d6194f4cebcb9480bf24b0600b4d23/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/'
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 
     // Config options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -344,7 +344,7 @@
                     "type": "string",
                     "fa_icon": "far fa-check-circle",
                     "description": "Base URL or local path to location of pipeline test dataset files",
-                    "default": "https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/bc94db3a30d6194f4cebcb9480bf24b0600b4d23/",
+                    "default": "https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/",
                     "hidden": true
                 },
                 "trace_report_suffix": {

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -22,11 +22,11 @@ nextflow_workflow {
                 ])
                 input[1] = channel.of([
                     [id:'SV'],
-                    file(params.pipelines_testdata_base_path + 'testdata/SV.tumor.esvee.somatic.37.vcf.gz.tbi', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.somatic.vcf.gz', checkIfExists: true)
                 ])
                 input[2] = channel.of([
                     [id:'SV'],
-                    file(params.pipelines_testdata_base_path + 'testdata/SV.tumor.esvee.somatic.37.vcf.gz', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz', checkIfExists: true)
                 ])
                 """
             }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -56,13 +56,13 @@
                 "alignments/subject_a_tumor.cram",
                 "alignments/subject_a_tumor.cram.crai",
                 "annotate_sv",
-                "annotate_sv/SV_svdbquery_vep.vcf.gz",
-                "annotate_sv/SV_svdbquery_vep.vcf.gz.tbi",
-                "annotate_sv/SV_svdbquery_vep.vcf.gz_summary.html",
+                "annotate_sv/subject_a_svdbquery_vep.vcf.gz",
+                "annotate_sv/subject_a_svdbquery_vep.vcf.gz.tbi",
+                "annotate_sv/subject_a_svdbquery_vep.vcf.gz_summary.html",
                 "clinical",
-                "clinical/SV_clinical.vcf",
+                "clinical/subject_a_clinical.vcf",
                 "clinical_filtering",
-                "clinical_filtering/SNV_clinical.vcf.gz",
+                "clinical_filtering/subject_a_clinical.vcf.gz",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -76,75 +76,75 @@
                 "pipeline_info",
                 "pipeline_info/oncorefiner_software_mqc_versions.yml",
                 "research",
-                "research/SV_research.vcf",
+                "research/subject_a_research.vcf",
                 "research_filtering",
-                "research_filtering/SNV_research.vcf.gz",
+                "research_filtering/subject_a_research.vcf.gz",
                 "svdb",
-                "svdb/SV_vcfdb_query.vcf",
+                "svdb/subject_a_vcfdb_query.vcf",
                 "vcf2cytosure",
                 "vcf2cytosure/normal.cgh",
                 "vcf2cytosure/tumor.cgh",
                 "vcfanno",
-                "vcfanno/SNV_vcfanno.vcf.gz",
-                "vcfanno/SNV_vcfanno.vcf.gz.tbi",
+                "vcfanno/subject_a_vcfanno.vcf.gz",
+                "vcfanno/subject_a_vcfanno.vcf.gz.tbi",
                 "vep",
-                "vep/SNV_vep.vcf.gz",
-                "vep/SNV_vep.vcf.gz.tbi",
-                "vep/SNV_vep.vcf.gz_summary.html"
+                "vep/subject_a_vep.vcf.gz",
+                "vep/subject_a_vep.vcf.gz.tbi",
+                "vep/subject_a_vep.vcf.gz_summary.html"
             ],
             [
-                "normal.cgh:md5,df9f0942e27e9c8f576c3d58a2e4ce29",
-                "tumor.cgh:md5,6982664c6f78b094fd4a26afc25e153e"
+                "normal.cgh:md5,7faf36d797590e61bb64688acf6417df",
+                "tumor.cgh:md5,3de27f40e256ee1861731cd6c6b27b6a"
             ],
             [
                 [
-                    "SV_svdbquery_vep.vcf.gz",
+                    "subject_a_svdbquery_vep.vcf.gz",
                     "VcfFile [chromosomes=[], sampleCount=2, variantCount=0, phased=true, phasedAutodetect=true]"
                 ],
                 [
-                    "SNV_clinical.vcf.gz",
+                    "subject_a_clinical.vcf.gz",
                     "VcfFile [chromosomes=[11, 22, 12, 13, 15, 16, 17, 18, 19, 1, 2, 3, 4, 5, 6, 7, 8, X, 9, 20, 21], sampleCount=2, variantCount=102, phased=false, phasedAutodetect=false]"
                 ],
                 [
-                    "SNV_research.vcf.gz",
+                    "subject_a_research.vcf.gz",
                     "VcfFile [chromosomes=[11, 22, 12, 13, 15, 16, 17, 18, 19, 1, 2, 3, 4, 5, 6, 7, 8, X, 9, 20, 21], sampleCount=2, variantCount=102, phased=false, phasedAutodetect=false]"
                 ],
                 [
-                    "SNV_vcfanno.vcf.gz",
+                    "subject_a_vcfanno.vcf.gz",
                     "VcfFile [chromosomes=[11, 22, 12, 13, 15, 16, 17, 18, 19, 1, 2, 3, 4, 5, 6, 7, 8, X, 9, 20, 21], sampleCount=2, variantCount=102, phased=false, phasedAutodetect=false]"
                 ],
                 [
-                    "SNV_vep.vcf.gz",
+                    "subject_a_vep.vcf.gz",
                     "VcfFile [chromosomes=[11, 22, 12, 13, 15, 16, 17, 18, 19, 1, 2, 3, 4, 5, 6, 7, 8, X, 9, 20, 21], sampleCount=2, variantCount=102, phased=false, phasedAutodetect=false]"
                 ]
             ],
             [
                 [
-                    "SV_svdbquery_vep.vcf.gz",
+                    "subject_a_svdbquery_vep.vcf.gz",
                     "d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 [
-                    "SNV_clinical.vcf.gz",
-                    "dd792f7ceac820af3fe366985474805"
+                    "subject_a_clinical.vcf.gz",
+                    "3ae83e0821730d9d187338e3828106fa"
                 ],
                 [
-                    "SNV_research.vcf.gz",
-                    "d7453d6080983d2c812113003f5e5ae8"
+                    "subject_a_research.vcf.gz",
+                    "e28954aa6ba6eda7add58297db6806c0"
                 ],
                 [
-                    "SNV_vcfanno.vcf.gz",
-                    "746d273c13550ab044af7eb5e62a941a"
+                    "subject_a_vcfanno.vcf.gz",
+                    "80f7be09a6f5e95e7d54072420a1074"
                 ],
                 [
-                    "SNV_vep.vcf.gz",
-                    "dd792f7ceac820af3fe366985474805"
+                    "subject_a_vep.vcf.gz",
+                    "3ae83e0821730d9d187338e3828106fa"
                 ]
             ]
         ],
+        "timestamp": "2026-04-13T14:03:48.423042",
         "meta": {
-            "nf-test": "0.9.3",
+            "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-04-09T17:36:09.024504"
+        }
     }
 }

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -12,7 +12,7 @@ params {
     config_profile_name          = 'Test profile'
     config_profile_description   = 'Minimal test dataset to check pipeline function'
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/bc94db3a30d6194f4cebcb9480bf24b0600b4d23/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/'
 }
 
 


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/CancerBioInfo/issues/131.

### Changed

- Update pipelines_testdata_base_path to point to the latest commit in `Clinical-Genomics/test-datasets/`.
- Update paths to test vcf files.