### PR TITLE
fix: add tbi to process snv workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#48](https://github.com/Clinical-Genomics/oncorefiner/pull/48) Updated documentation.
 - [#67](https://github.com/Clinical-Genomics/oncorefiner/pull/67) `--help` parameter not working
 - [#72](https://github.com/Clinical-Genomics/oncorefiner/pull/72) Added subworkflow test to `PREPARE_REFERENCES`
+- [#82](https://github.com/Clinical-Genomics/oncorefiner/pull/82) Add index files for SNV clinical and research filtered vcfs
 
 ### `Dependencies`
 

--- a/conf/subworkflows/process_snvs.config
+++ b/conf/subworkflows/process_snvs.config
@@ -24,7 +24,7 @@ process {
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_RESEARCH' {
       ext {
          prefix = { "${meta.id}_research" }
-         args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
+         args = """ --output-type z --write-index=tbi --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
          //args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".") && (INFO/SWEGENAF <= 0.01 || INFO/SWEGENAF == ".")' """
          //TO DO down the line: use above filtering parameters when annotation is in place
          // modules.config takes preference over test.config, and we currently dont have support for SWEGEN filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.
@@ -53,7 +53,7 @@ process {
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_CLINICAL' {
       ext {
          prefix = { "${meta.id}_clinical" }
-         args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
+         args = """ --output-type z --write-index=tbi --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
          //args = """ --output-type z --include '(INFO/ArtefactFrq <= 0.1 || INFO/ArtefactFrq == ".") && (INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".") && (INFO/SWEGENAF <= 0.01 || INFO/SWEGENAF == ".") && (INFO/Frq <= 0.007 || INFO/Frq == ".")' """
          //TO DO down the line: use above filtering parameters when annotation is in place
         // modules.config takes preference over test.config, and we currently dont have support for SWEGEN or ArtefactFrq filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.

--- a/subworkflows/local/process_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/process_snvs/tests/main.nf.test.snap
@@ -4,8 +4,10 @@
             [
                 "clinical_filtering",
                 "clinical_filtering/SNV_clinical.vcf.gz",
+                "clinical_filtering/SNV_clinical.vcf.gz.tbi",
                 "research_filtering",
                 "research_filtering/SNV_research.vcf.gz",
+                "research_filtering/SNV_research.vcf.gz.tbi",
                 "vcfanno",
                 "vcfanno/SNV_vcfanno.vcf.gz",
                 "vcfanno/SNV_vcfanno.vcf.gz.tbi",
@@ -37,6 +39,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-22T11:02:31.832827"
+        "timestamp": "2026-04-27T14:15:15.370423"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -46,6 +46,7 @@
                 "alignments/subject_a_tumor.cram.crai",
                 "clinical_filtering",
                 "clinical_filtering/subject_a_clinical.vcf.gz",
+                "clinical_filtering/subject_a_clinical.vcf.gz.tbi",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -66,6 +67,7 @@
                 "process_svs/subject_a_vcfdb_query.vcf",
                 "research_filtering",
                 "research_filtering/subject_a_research.vcf.gz",
+                "research_filtering/subject_a_research.vcf.gz.tbi",
                 "vcf2cytosure",
                 "vcf2cytosure/normal.cgh",
                 "vcf2cytosure/tumor.cgh",
@@ -149,6 +151,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-23T17:04:52.433507"
+        "timestamp": "2026-04-27T14:28:49.640751"
     }
 }


### PR DESCRIPTION
### Added

-

### Changed

- Added tbi for bcftools_research and bcftools_clinical for the SNV process
- Updated subworkflow snapshot and default snapshot

### Fixed

-

### Removed

-
