### PR TITLE
docs: Fix dead link to nf-core style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#48](https://github.com/Clinical-Genomics/oncorefiner/pull/48) Updated documentation.
 - [#67](https://github.com/Clinical-Genomics/oncorefiner/pull/67) `--help` parameter not working
 - [#72](https://github.com/Clinical-Genomics/oncorefiner/pull/72) Added subworkflow test to `PREPARE_REFERENCES`
+- [#80](https://github.com/Clinical-Genomics/oncorefiner/pull/80) Dead link to nf-core style guide in `docs/CONTRIBUTING.md`
 
 ### `Dependencies`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Add the tool to the relevant numbered section in the **Pipeline summary**. If th
 
 ### Images and figures
 
-For overview images and other documents we follow the nf-core [style guidelines and examples](https://nf-co.re/developers/design_guidelines).
+For overview images and other documents we follow the nf-core [style guide](https://nf-co.re/docs/developing/documentation/style-guide).
 
 ## Coding conventions
 


### PR DESCRIPTION
Closes #80 

### Added

-

### Changed

-

### Fixed

-  Dead link to nf-core style guide in Contribution Guidelines

### Removed

-
