### PR TITLE
feat: add cnv report

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -16,6 +16,8 @@ Define where the pipeline should find input data and save output data.
 | `bai_tumor` | Path to BAM index file for the tumor sample. | `string` |  |  |  |
 | `bam_normal` | Path to alignment BAM file for the normal sample. | `string` |  |  |  |
 | `bai_normal` | Path to BAM index file for the normal sample. | `string` |  |  |  |
+| `cnv_gene` | Path to a file containing gene-level CNV calls. | `string` |  |  |  |
+| `cnv_segment` | Path to a file containing segment-level CNV calls. | `string` |  |  |  |
 | `sex` | Sex of the patient. (accepted: `female`\|`male`\|`unknown`) | `string` |  |  |  |
 | `email` | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.</small></details>| `string` |  |  |  |
 | `multiqc_title` | MultiQC report title. Printed as page header, used for filename if not otherwise specified. | `string` |  |  |  |

--- a/modules/local/cnv_report/environment.yml
+++ b/modules/local/cnv_report/environment.yml
@@ -1,8 +1,8 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
 dependencies:
-- conda-forge::r-base=4.4.3
-- conda-forge::r-dt=0.34.0
-- conda-forge::r-readr=2.1.5
-- conda-forge::r-rmarkdown=2.29
+  - conda-forge::r-base=4.4.3
+  - conda-forge::r-dt=0.34.0
+  - conda-forge::r-readr=2.1.5
+  - conda-forge::r-rmarkdown=2.29

--- a/modules/local/cnv_report/environment.yml
+++ b/modules/local/cnv_report/environment.yml
@@ -1,0 +1,8 @@
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- conda-forge::r-base=4.4.3
+- conda-forge::r-dt=0.34.0
+- conda-forge::r-readr=2.1.5
+- conda-forge::r-rmarkdown=2.29

--- a/modules/local/cnv_report/main.nf
+++ b/modules/local/cnv_report/main.nf
@@ -29,7 +29,7 @@ process CNV_REPORT {
             cnv_segment = "${cnv_segment}" \\
         ), \\
         output_file = "${prefix}.html" \\
-    )' 
+    )'
     """
 
     stub:

--- a/modules/local/cnv_report/main.nf
+++ b/modules/local/cnv_report/main.nf
@@ -12,7 +12,9 @@ process CNV_REPORT {
     tuple val(meta), path(rmd_template), path(cnv_gene), path(cnv_segment)
 
     output:
-    tuple val(meta), path("*.html"), emit: report
+    tuple val(meta), path("*.html")             , emit: report
+    path  "versions.yml"                        , emit: versions
+    tuple val("${task.process}"), val('rmarkdown'), eval("Rscript -e 'cat(paste(packageVersion('rmarkdown'), collapse='.'))'"), topic: versions, emit: versions_rmarkdown
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,13 +29,12 @@ process CNV_REPORT {
             cnv_segment = "${cnv_segment}" \\
         ), \\
         output_file = "${prefix}.html" \\
-    )' \\
+    )' 
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}_cnv_report"
     """
     touch ${prefix}.html
-    """
 
 }

--- a/modules/local/cnv_report/main.nf
+++ b/modules/local/cnv_report/main.nf
@@ -1,0 +1,39 @@
+process CNV_REPORT {
+    tag "${meta.id}"
+    label 'process_single'
+
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://community.wave.seqera.io/library/r-base_r-dt_r-readr_r-rmarkdown:8612e5aa5384f180' :
+        'community.wave.seqera.io/library/r-base_r-dt_r-readr_r-rmarkdown:5c3b8868d1024810' }"
+
+    input:
+    tuple val(meta), path(rmd_template), path(cnv_gene), path(cnv_segment)
+
+    output:
+    tuple val(meta), path("*.html"), emit: report
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}_cnv_report"
+    """
+    Rscript -e 'rmarkdown::render("${rmd_template}", \\
+        params = list( \\
+            cnv_gene = "${cnv_gene}", \\
+            cnv_segment = "${cnv_segment}" \\
+        ), \\
+        output_file = "${prefix}.html" \\
+    )' \\
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}_cnv_report"
+    """
+    touch ${prefix}.html
+    """
+
+}

--- a/modules/local/cnv_report/meta.yml
+++ b/modules/local/cnv_report/meta.yml
@@ -1,0 +1,46 @@
+name: cnv_report
+description: Render a HTML report for CNV results using R Markdown.
+keywords:
+  - cnv
+  - copy number variation
+  - report
+  - rmarkdown
+  - html
+tools:
+  - rmarkdown:
+      description: Dynamic Documents for R
+      homepage: https://rmarkdown.rstudio.com/
+      documentation: https://rmarkdown.rstudio.com/lesson-1.html
+      tool_dev_url: https://github.com/rstudio/rmarkdown
+      licence:
+        - "GPL-3"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - rmd_template:
+        type: file
+        description: Rmarkdown file
+        pattern: "*.{Rmd}"
+        ontologies:
+          - edam: http://edamontology.org/format_4000
+    - cnv_gene:
+        type: file
+        description: TSV file containing gene-level CNV results.
+        pattern: "*.tsv"
+    - cnv_segment:
+        type: file
+        description: TSV file containing segment-level CNV results.
+        pattern: "*.tsv"
+output:
+  - report:
+      type: file
+      description: Rendered CNV HTML report.
+      pattern: "*.html"
+authors:
+  - "@Clinical-Genomics/cancer"
+maintainers:
+  - "@Clinical-Genomics/cancer"

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,8 @@ params {
     bai_tumor                   = null
     bam_normal                  = null
     bai_normal                  = null
+    cnv_gene                    = null
+    cnv_segment                 = null
     sex                         = null
 
     // CADD

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -77,6 +77,22 @@
                     "format": "file-path",
                     "exists": true
                 },
+                "cnv_gene": {
+                    "type": "string",
+                    "description": "Path to a file containing gene-level CNV calls.",
+                    "fa_icon": "fas fa-file",
+                    "pattern": "^\\S+\\.tsv$",
+                    "format": "file-path",
+                    "exists": true
+                },
+                "cnv_segment": {
+                    "type": "string",
+                    "description": "Path to a file containing segment-level CNV calls.",
+                    "fa_icon": "fas fa-file",
+                    "pattern": "^\\S+\\.tsv$",
+                    "format": "file-path",
+                    "exists": true
+                },
                 "sex": {
                     "type": "string",
                     "enum": ["female", "male", "unknown"],


### PR DESCRIPTION
Closes: https://github.com/Clinical-Genomics/MTP-oncoflow/issues/34

### Added

- CNV report


### Note

There is a https://nf-co.re/modules/rmarkdownnotebook module

However it was unsure about using it or not as: 
- the environment lacks R packages that are needed by the CNV report
- the main.nf add also more logic and complexity and I didn't have the time to check it. I'll check further whenever I have time



