### PR TITLE
fix: Update publishing strategy for `PROCESS_SVS`

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,12 +12,6 @@
 
 process {
 
-    publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
-
     withName: 'MULTIQC' {
         ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
         publishDir = [
@@ -26,8 +20,6 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-
-
 
     withName: 'SAMTOOLS_VIEW' {
         ext.prefix = { "${input.simpleName}_${meta.type}" }

--- a/conf/subworkflows/process_snvs.config
+++ b/conf/subworkflows/process_snvs.config
@@ -24,7 +24,7 @@ process {
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_RESEARCH' {
       ext {
          prefix = { "${meta.id}_research" }
-         args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
+         args = """ --output-type z --write-index=tbi --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
          //args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".") && (INFO/SWEGENAF <= 0.01 || INFO/SWEGENAF == ".")' """
          //TO DO down the line: use above filtering parameters when annotation is in place
          // modules.config takes preference over test.config, and we currently dont have support for SWEGEN filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.

--- a/conf/subworkflows/process_snvs.config
+++ b/conf/subworkflows/process_snvs.config
@@ -53,7 +53,7 @@ process {
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_CLINICAL' {
       ext {
          prefix = { "${meta.id}_clinical" }
-         args = """ --output-type z --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
+         args = """ --output-type z --write-index=tbi --include '(INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".")' """
          //args = """ --output-type z --include '(INFO/ArtefactFrq <= 0.1 || INFO/ArtefactFrq == ".") && (INFO/GNOMADAF_popmax <= 0.001 || INFO/GNOMADAF_popmax == ".") && (INFO/SWEGENAF <= 0.01 || INFO/SWEGENAF == ".") && (INFO/Frq <= 0.007 || INFO/Frq == ".")' """
          //TO DO down the line: use above filtering parameters when annotation is in place
         // modules.config takes preference over test.config, and we currently dont have support for SWEGEN or ArtefactFrq filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.

--- a/conf/subworkflows/process_snvs.config
+++ b/conf/subworkflows/process_snvs.config
@@ -14,11 +14,6 @@ process {
 
     withName: '.*PROCESS_SNVS:VCFANNO' {
         ext.prefix = { "${meta.id}_vcfanno" }
-        publishDir = [
-            path: { "${params.outdir}/vcfanno" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
     }
 
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_RESEARCH' {
@@ -29,11 +24,6 @@ process {
          //TO DO down the line: use above filtering parameters when annotation is in place
          // modules.config takes preference over test.config, and we currently dont have support for SWEGEN filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.
       }
-      publishDir = [
-            path: { "${params.outdir}/research_filtering" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
    }
 
     withName: '.*PROCESS_SNVS:ENSEMBLVEP_VEP' {
@@ -43,11 +33,6 @@ process {
             '--vcf --buffer_size 20000 --max_sv_size 248956422',
             '--format vcf --offline --merged  --cache --force_overwrite'
         ].join(' ') }
-        publishDir = [
-            path: { "${params.outdir}/vep" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
     }
 
     withName:'.*PROCESS_SNVS:BCFTOOLS_VIEW_CLINICAL' {
@@ -58,11 +43,6 @@ process {
          //TO DO down the line: use above filtering parameters when annotation is in place
         // modules.config takes preference over test.config, and we currently dont have support for SWEGEN or ArtefactFrq filtering in test profile, thus for now, we need to remove these from the filtering until this is in place.
       }
-      publishDir = [
-            path: { "${params.outdir}/clinical_filtering" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
    }
 
 }

--- a/main.nf
+++ b/main.nf
@@ -174,7 +174,11 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     SAMTOOLS_VIEW ( ch_samtools_in.bam_bai, ch_samtools_in.fasta_fai, [[], []], [[],[]], 'crai' )
 
     emit:
-    multiqc_report = ONCOREFINER.out.multiqc_report // channel: /path/to/multiqc_report.html
+    multiqc_report            = ONCOREFINER.out.multiqc_report            // channel: /path/to/multiqc_report.html
+    snv_vcfanno_vcf           = ONCOREFINER.out.snv_vcfanno_vcf           // channel: [val(meta), path(vcf)]
+    snv_vcfanno_tbi           = ONCOREFINER.out.snv_vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
+    snv_research_filtered_vcf = ONCOREFINER.out.snv_research_filtered_vcf // channel: [val(meta), path(vcf)]
+    snv_research_filtered_tbi = ONCOREFINER.out.snv_research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
 }
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -239,6 +243,21 @@ workflow {
         params.hook_url,
         CLINICALGENOMICS_ONCOREFINER.out.multiqc_report
     )
+
+    //
+    // WORKFLOW OUTPUTS: Group files by publish directory
+    //
+
+    ch_snv_publish = CLINICALGENOMICS_ONCOREFINER.out.snv_vcfanno_vcf
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vcfanno_tbi)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_research_filtered_vcf)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_research_filtered_tbi)
+
+    // Publish
+
+
+
+    // Output block
 }
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -174,9 +174,16 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     SAMTOOLS_VIEW ( ch_samtools_in.bam_bai, ch_samtools_in.fasta_fai, [[], []], [[],[]], 'crai' )
 
     emit:
+    cadd_annotated_vcf        = ONCOREFINER.out.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
+    cadd_annotated_tbi        = ONCOREFINER.out.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
     multiqc_report            = ONCOREFINER.out.multiqc_report            // channel: /path/to/multiqc_report.html
+    snv_clinical_filtered_vcf = ONCOREFINER.out.snv_clinical_filtered_vcf // channel: [val(meta), path(vcf)]
+    snv_clinical_filtered_tbi = ONCOREFINER.out.snv_clinical_filtered_tbi // channel: [val(meta), path(tbi)]
     snv_vcfanno_vcf           = ONCOREFINER.out.snv_vcfanno_vcf           // channel: [val(meta), path(vcf)]
     snv_vcfanno_tbi           = ONCOREFINER.out.snv_vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
+    snv_vep_annotated_vcf     = ONCOREFINER.out.snv_vep_annotated_vcf     // channel: [val(meta), path(vcf)]
+    snv_vep_annotated_tbi     = ONCOREFINER.out.snv_vep_annotated_tbi     // channel: [val(meta), path(tbi)]
+    snv_vep_report            = ONCOREFINER.out.snv_vep_report            // channel: [val(meta), val(process), val(tool), path(html)]
     snv_research_filtered_vcf = ONCOREFINER.out.snv_research_filtered_vcf // channel: [val(meta), path(vcf)]
     snv_research_filtered_tbi = ONCOREFINER.out.snv_research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
 }
@@ -247,17 +254,26 @@ workflow {
     //
     // WORKFLOW OUTPUTS: Group files by publish directory
     //
-
-    ch_snv_publish = CLINICALGENOMICS_ONCOREFINER.out.snv_vcfanno_vcf
+    ch_snv_publish = CLINICALGENOMICS_ONCOREFINER.out.cadd_annotated_vcf
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.cadd_annotated_tbi)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_clinical_filtered_vcf)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_clinical_filtered_tbi)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vcfanno_vcf)
                     .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vcfanno_tbi)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vep_annotated_vcf)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vep_annotated_tbi)
+                    .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_vep_report)
                     .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_research_filtered_vcf)
                     .mix(CLINICALGENOMICS_ONCOREFINER.out.snv_research_filtered_tbi)
 
-    // Publish
+    publish:
+        snv = ch_snv_publish
+}
 
-
-
-    // Output block
+output {
+    snv {
+        path "snv"
+    }
 }
 
 /*

--- a/subworkflows/local/generate_cytosure_files/main.nf
+++ b/subworkflows/local/generate_cytosure_files/main.nf
@@ -37,4 +37,7 @@ workflow GENERATE_CYTOSURE_FILES {
             [[],[]],
             []
         )
+
+    emit:
+        cgh = VCF2CYTOSURE.out.cgh
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -123,7 +123,7 @@ workflow PROCESS_SNVS {
         vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
-        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
+        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(ensemblvep), path(html)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -108,4 +108,10 @@ workflow PROCESS_SNVS {
             .set { ch_clinical_filtering_in }
 
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
+
+    emit:
+        vcfanno_vcf = VCFANNO.out.vcf                          // channel: [val(meta), path(vcf)]
+        vcfanno_tbi = VCFANNO.out.tbi                          // channel: [val(meta), path(vcf.tbi)]
+        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(vcf.tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -1,5 +1,5 @@
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -71,8 +71,6 @@ workflow PROCESS_SNVS {
                 .set { ch_vep_snv }
 
         // ANNOTATE WITH CADD - currently depends on val_cadd_resources - could be improved?
-        ch_cadd_vcf = channel.empty()
-        ch_cadd_tbi = channel.empty()
         if (val_cadd_resources) {
 
             ch_cadd_in = BCFTOOLS_VIEW_RESEARCH.out.vcf
@@ -89,9 +87,6 @@ workflow PROCESS_SNVS {
             ANNOTATE_CADD.out.vcf
                 .join(ANNOTATE_CADD.out.tbi)
                 .set { ch_vep_snv }
-
-            ch_cadd_vcf = ANNOTATE_CADD.out.vcf
-            ch_cadd_tbi = ANNOTATE_CADD.out.tbi
         }
 
         ENSEMBLVEP_VEP (
@@ -113,17 +108,4 @@ workflow PROCESS_SNVS {
             .set { ch_clinical_filtering_in }
 
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
-
-    emit:
-        cadd_annotated_vcf    = ch_cadd_vcf                    // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(tbi)]
-        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf // channel: [val(meta), path(vcf)]
-        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi // channel: [val(meta), path(tbi)]
-        vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
-        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
-        vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
-        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
-        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
-        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
-        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -71,6 +71,8 @@ workflow PROCESS_SNVS {
                 .set { ch_vep_snv }
 
         // ANNOTATE WITH CADD - currently depends on val_cadd_resources - could be improved?
+        ch_cadd_vcf = channel.empty()
+        ch_cadd_tbi = channel.empty()
         if (val_cadd_resources) {
 
             ch_cadd_in = BCFTOOLS_VIEW_RESEARCH.out.vcf
@@ -87,6 +89,9 @@ workflow PROCESS_SNVS {
             ANNOTATE_CADD.out.vcf
                 .join(ANNOTATE_CADD.out.tbi)
                 .set { ch_vep_snv }
+            
+            ch_cadd_vcf = ANNOTATE_CADD.out.vcf
+            ch_cadd_tbi = ANNOTATE_CADD.out.tbi
         }
 
         ENSEMBLVEP_VEP (
@@ -114,4 +119,7 @@ workflow PROCESS_SNVS {
         vcfanno_tbi = VCFANNO.out.tbi                          // channel: [val(meta), path(vcf.tbi)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(vcf.tbi)]
+        cadd_annotated_vcf = ch_cadd_vcf                       // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi = ch_cadd_tbi                       // channel: [val(meta), path(vcf.tbi)]
+
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -116,12 +116,12 @@ workflow PROCESS_SNVS {
 
     emit:
         vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
-        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(vcf.tbi)]
+        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
-        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(vcf.tbi)]
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
         cadd_annotated_vcf    = ch_cadd_vcf                    // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(vcf.tbi)]
+        cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(tbi)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
-        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(vcf.tbi)]
+        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
         vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -123,7 +123,7 @@ workflow PROCESS_SNVS {
         vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
-        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(ensemblvep), path(html)]
+        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -124,4 +124,6 @@ workflow PROCESS_SNVS {
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
         vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -71,6 +71,8 @@ workflow PROCESS_SNVS {
                 .set { ch_vep_snv }
 
         // ANNOTATE WITH CADD - currently depends on val_cadd_resources - could be improved?
+        ch_cadd_vcf = channel.empty()
+        ch_cadd_tbi = channel.empty()
         if (val_cadd_resources) {
 
             ch_cadd_in = BCFTOOLS_VIEW_RESEARCH.out.vcf
@@ -87,6 +89,9 @@ workflow PROCESS_SNVS {
             ANNOTATE_CADD.out.vcf
                 .join(ANNOTATE_CADD.out.tbi)
                 .set { ch_vep_snv }
+
+            ch_cadd_vcf = ANNOTATE_CADD.out.vcf
+            ch_cadd_tbi = ANNOTATE_CADD.out.tbi
         }
 
         ENSEMBLVEP_VEP (
@@ -108,4 +113,17 @@ workflow PROCESS_SNVS {
             .set { ch_clinical_filtering_in }
 
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
+
+    emit:
+        cadd_annotated_vcf    = ch_cadd_vcf                    // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(tbi)]
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi // channel: [val(meta), path(tbi)]
+        vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
+        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
+        vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
+        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
+        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
+        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -89,7 +89,7 @@ workflow PROCESS_SNVS {
             ANNOTATE_CADD.out.vcf
                 .join(ANNOTATE_CADD.out.tbi)
                 .set { ch_vep_snv }
-            
+
             ch_cadd_vcf = ANNOTATE_CADD.out.vcf
             ch_cadd_tbi = ANNOTATE_CADD.out.tbi
         }
@@ -115,11 +115,13 @@ workflow PROCESS_SNVS {
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
 
     emit:
-        vcfanno_vcf = VCFANNO.out.vcf                          // channel: [val(meta), path(vcf)]
-        vcfanno_tbi = VCFANNO.out.tbi                          // channel: [val(meta), path(vcf.tbi)]
+        vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
+        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(vcf.tbi)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(vcf.tbi)]
-        cadd_annotated_vcf = ch_cadd_vcf                       // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi = ch_cadd_tbi                       // channel: [val(meta), path(vcf.tbi)]
-
+        cadd_annotated_vcf    = ch_cadd_vcf                    // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(vcf.tbi)]
+        vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
+        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(vcf.tbi)]
+        vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
 }

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -1,5 +1,5 @@
-/*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/*
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -115,15 +115,15 @@ workflow PROCESS_SNVS {
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
 
     emit:
-        vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
-        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
-        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
-        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
         cadd_annotated_vcf    = ch_cadd_vcf                    // channel: [val(meta), path(vcf)]
         cadd_annotated_tbi    = ch_cadd_tbi                    // channel: [val(meta), path(tbi)]
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi // channel: [val(meta), path(tbi)]
+        vcfanno_vcf           = VCFANNO.out.vcf                // channel: [val(meta), path(vcf)]
+        vcfanno_tbi           = VCFANNO.out.tbi                // channel: [val(meta), path(tbi)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
         vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
-        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
-        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
+        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_svs/main.nf
+++ b/subworkflows/local/process_svs/main.nf
@@ -115,4 +115,15 @@ workflow PROCESS_SVS {
             ch_vcf2cytosure_in.tbi,
             ch_vcf2cytosure_in.vcf
         )
+
+    emit:
+        svdb_vcf = SVDB_QUERY.out.vcf
+        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi
+        vep_annotated_vcf = ENSEMBLVEP_VEP.out.vcf
+        vep_annotated_tbi = ENSEMBLVEP_VEP.out.tbi
+        vep_report = ENSEMBLVEP_VEP.out.report
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi
+        cgh = GENERATE_CYTOSURE_FILES.out.cgh
 }

--- a/subworkflows/local/process_svs/main.nf
+++ b/subworkflows/local/process_svs/main.nf
@@ -117,13 +117,13 @@ workflow PROCESS_SVS {
         )
 
     emit:
-        svdb_vcf              = SVDB_QUERY.out.vcf              // channel: [val(meta), path(vcf)]
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
         research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf  // channel: [val(meta), path(vcf)]
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi  // channel: [val(meta), path(tbi)]
+        svdb_vcf              = SVDB_QUERY.out.vcf              // channel: [val(meta), path(vcf)]
+        vcf2cytosure_cgh      = GENERATE_CYTOSURE_FILES.out.cgh // channel: [val(meta), path(cgh)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf          // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi          // channel: [val(meta), path(tbi)]
         vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), path(html)]
-        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
-        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
-        vcf2cytosure_cgh      = GENERATE_CYTOSURE_FILES.out.cgh // channel: [val(meta), path(cgh)]
 }

--- a/subworkflows/local/process_svs/main.nf
+++ b/subworkflows/local/process_svs/main.nf
@@ -117,13 +117,13 @@ workflow PROCESS_SVS {
         )
 
     emit:
-        svdb_vcf = SVDB_QUERY.out.vcf
-        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf
-        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi
-        vep_annotated_vcf = ENSEMBLVEP_VEP.out.vcf
-        vep_annotated_tbi = ENSEMBLVEP_VEP.out.tbi
-        vep_report = ENSEMBLVEP_VEP.out.report
-        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf
-        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi
-        cgh = GENERATE_CYTOSURE_FILES.out.cgh
+        svdb_vcf              = SVDB_QUERY.out.vcf              // channel: [val(meta), path(vcf)]
+        research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf  // channel: [val(meta), path(vcf)]
+        research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi  // channel: [val(meta), path(tbi)]
+        vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf          // channel: [val(meta), path(vcf)]
+        vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi          // channel: [val(meta), path(tbi)]
+        vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), path(report)]
+        clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
+        vcf2cytosure_cgh      = GENERATE_CYTOSURE_FILES.out.cgh // channel: [val(meta), path(cgh)]
 }

--- a/subworkflows/local/process_svs/main.nf
+++ b/subworkflows/local/process_svs/main.nf
@@ -122,7 +122,7 @@ workflow PROCESS_SVS {
         research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi  // channel: [val(meta), path(tbi)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf          // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi          // channel: [val(meta), path(tbi)]
-        vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), path(report)]
+        vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), path(html)]
         clinical_filtered_vcf = BCFTOOLS_VIEW_CLINICAL.out.vcf  // channel: [val(meta), path(vcf)]
         clinical_filtered_tbi = BCFTOOLS_VIEW_CLINICAL.out.tbi  // channel: [val(meta), path(tbi)]
         vcf2cytosure_cgh      = GENERATE_CYTOSURE_FILES.out.cgh // channel: [val(meta), path(cgh)]

--- a/subworkflows/local/process_svs/main.nf
+++ b/subworkflows/local/process_svs/main.nf
@@ -125,5 +125,5 @@ workflow PROCESS_SVS {
         vcf2cytosure_cgh      = GENERATE_CYTOSURE_FILES.out.cgh // channel: [val(meta), path(cgh)]
         vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf          // channel: [val(meta), path(vcf)]
         vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi          // channel: [val(meta), path(tbi)]
-        vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), path(html)]
+        vep_report            = ENSEMBLVEP_VEP.out.report       // channel: [val(meta), val(process), val(tool), path(html)]
 }

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -200,7 +200,6 @@ workflow ONCOREFINER {
         sv_research_filtered_tbi  = PROCESS_SVS.out.research_filtered_tbi  // channel: [val(meta), path(tbi)]
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]
 
-
 }
 
 /*

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,8 +178,12 @@ workflow ONCOREFINER {
         )
 
     emit:
-    multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
-    versions       = ch_versions                 // channel: [ path(versions.yml) ]
+    multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
+    snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
+    snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
+    snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
+    snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
+    versions                  = ch_versions                            // channel: [ path(versions.yml) ]
 
 }
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,8 +178,19 @@ workflow ONCOREFINER {
         )
 
     emit:
-    multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
-    versions       = ch_versions                 // channel: [ path(versions.yml) ]
+        cadd_annotated_vcf    = PROCESS_SNVS.cadd_annotated_vcf    // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi    = PROCESS_SNVS.cadd_annotated_tbi    // channel: [val(meta), path(tbi)]
+        clinical_filtered_vcf = PROCESS_SNVS.clinical_filtered_vcf // channel: [val(meta), path(vcf)]
+        clinical_filtered_tbi = PROCESS_SNVS.clinical_filtered_tbi // channel: [
+        vcfanno_vcf           = PROCESS_SNVS.vcfanno_vcf           // channel: [val(meta), path(vcf)]
+        vcfanno_tbi           = PROCESS_SNVS.vcfanno_tbi           // channel: [val(meta), path(tbi)]
+        vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf     // channel: [val(meta), path(vcf)]
+        vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi     // channel: [val(meta), path(tbi)]
+        vep_report            = PROCESS_SNVS.vep_report            // channel: [val(meta), val(process), val(tool), path(html)]
+        research_filtered_vcf = PROCESS_SNVS.research_filtered_vcf // channel: [val(meta), path(vcf)]
+        research_filtered_tbi = PROCESS_SNVS.research_filtered_tbi // channel: [val(meta), path(tbi)]
+        multiqc_report        = MULTIQC.out.report.toList()        // channel: /path/to/multiqc_report.html
+        versions              = ch_versions                       // channel: [ path(versions.yml) ]
 
 }
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,19 +178,19 @@ workflow ONCOREFINER {
         )
 
     emit:
-    cadd_annotated_vcf        = PROCESS_SNVS.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
-    cadd_annotated_tbi        = PROCESS_SNVS.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
-    multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
-    snv_clinical_filtered_vcf = PROCESS_SNVS.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
-    snv_clinical_filtered_tbi = PROCESS_SNVS.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
-    snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
-    snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
-    snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
-    snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-    snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
-    snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
-    snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
-    versions                  = ch_versions                            // channel: [ path(versions.yml) ]
+        cadd_annotated_vcf        = PROCESS_SNVS.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi        = PROCESS_SNVS.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
+        multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
+        snv_clinical_filtered_vcf = PROCESS_SNVS.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
+        snv_clinical_filtered_tbi = PROCESS_SNVS.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
+        snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
+        snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
+        snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
+        snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
+        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
+        snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
+        versions                  = ch_versions                            // channel: [ path(versions.yml) ]
 
 }
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -190,7 +190,7 @@ workflow ONCOREFINER {
         research_filtered_vcf = PROCESS_SNVS.research_filtered_vcf // channel: [val(meta), path(vcf)]
         research_filtered_tbi = PROCESS_SNVS.research_filtered_tbi // channel: [val(meta), path(tbi)]
         multiqc_report        = MULTIQC.out.report.toList()        // channel: /path/to/multiqc_report.html
-        versions              = ch_versions                       // channel: [ path(versions.yml) ]
+        versions              = ch_versions                        // channel: [ path(versions.yml) ]
 
 }
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -187,7 +187,7 @@ workflow ONCOREFINER {
         snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
         snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
         snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(ensemblvep), path(html)]
         snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
         snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -187,7 +187,7 @@ workflow ONCOREFINER {
         snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
         snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
         snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(ensemblvep), path(html)]
+        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
         snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
         snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,27 +178,26 @@ workflow ONCOREFINER {
         )
 
     emit:
-        cadd_annotated_vcf        = PROCESS_SNVS.out.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi        = PROCESS_SNVS.out.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
+        cadd_annotated_vcf        = PROCESS_SNVS.out.cadd_annotated_vcf    // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi        = PROCESS_SNVS.out.cadd_annotated_tbi    // channel: [val(meta), path(tbi)]
         multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
-        snv_clinical_filtered_vcf = PROCESS_SNVS.out.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
-        snv_clinical_filtered_tbi = PROCESS_SNVS.out.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
+        snv_clinical_filtered_vcf = PROCESS_SNVS.out.clinical_filtered_vcf // channel: [val(meta), path(vcf)]
+        snv_clinical_filtered_tbi = PROCESS_SNVS.out.clinical_filtered_tbi // channel: [val(meta), path(tbi)]
         snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
         snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
-        snv_vep_annotated_vcf     = PROCESS_SNVS.out.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
-        snv_vep_annotated_tbi     = PROCESS_SNVS.out.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        snv_vep_report            = PROCESS_SNVS.out.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        snv_vep_annotated_vcf     = PROCESS_SNVS.out.vep_annotated_vcf     // channel: [val(meta), path(vcf)]
+        snv_vep_annotated_tbi     = PROCESS_SNVS.out.vep_annotated_tbi     // channel: [val(meta), path(tbi)]
+        snv_vep_report            = PROCESS_SNVS.out.vep_report            // channel: [val(meta), val(process), val(tool), path(html)]
         snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
         snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
-        sv_clinical_filtered_vcf  = PROCESS_SVS.out.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
-        sv_clinical_filtered_tbi  = PROCESS_SVS.out.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
-        sv_vep_annotated_vcf      = PROCESS_SVS.out.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
-        sv_vep_annotated_tbi      = PROCESS_SVS.out.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        sv_vep_report             = PROCESS_SVS.out.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
-        sv_svdb_vcf               = PROCESS_SVS.out.svdb_vcf                  // channel: [val(meta), path(vcf)]
-        sv_research_filtered_vcf  = PROCESS_SVS.out.research_filtered_vcf     // channel: [val(meta), path(vcf)]
-        sv_research_filtered_tbi  = PROCESS_SVS.out.research_filtered_tbi     // channel: [val(meta), path(tbi)]
-
+        sv_clinical_filtered_vcf  = PROCESS_SVS.out.clinical_filtered_vcf  // channel: [val(meta), path(vcf)]
+        sv_clinical_filtered_tbi  = PROCESS_SVS.out.clinical_filtered_tbi  // channel: [val(meta), path(tbi)]
+        sv_vep_annotated_vcf      = PROCESS_SVS.out.vep_annotated_vcf      // channel: [val(meta), path(vcf)]
+        sv_vep_annotated_tbi      = PROCESS_SVS.out.vep_annotated_tbi      // channel: [val(meta), path(tbi)]
+        sv_vep_report             = PROCESS_SVS.out.vep_report             // channel: [val(meta), val(process), val(tool), path(html)]
+        sv_svdb_vcf               = PROCESS_SVS.out.svdb_vcf               // channel: [val(meta), path(vcf)]
+        sv_research_filtered_vcf  = PROCESS_SVS.out.research_filtered_vcf  // channel: [val(meta), path(vcf)]
+        sv_research_filtered_tbi  = PROCESS_SVS.out.research_filtered_tbi  // channel: [val(meta), path(tbi)]
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]
 
 

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,16 +178,16 @@ workflow ONCOREFINER {
         )
 
     emit:
-        cadd_annotated_vcf        = PROCESS_SNVS.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi        = PROCESS_SNVS.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
+        cadd_annotated_vcf        = PROCESS_SNVS.out.cadd_annotated_vcf    // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi        = PROCESS_SNVS.out.cadd_annotated_tbi    // channel: [val(meta), path(tbi)]
         multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
-        snv_clinical_filtered_vcf = PROCESS_SNVS.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
-        snv_clinical_filtered_tbi = PROCESS_SNVS.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
+        snv_clinical_filtered_vcf = PROCESS_SNVS.out.clinical_filtered_vcf // channel: [val(meta), path(vcf)]
+        snv_clinical_filtered_tbi = PROCESS_SNVS.out.clinical_filtered_tbi // channel: [val(meta), path(tbi)]
         snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
         snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
-        snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
-        snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        snv_vep_annotated_vcf     = PROCESS_SNVS.out.vep_annotated_vcf     // channel: [val(meta), path(vcf)]
+        snv_vep_annotated_tbi     = PROCESS_SNVS.out.vep_annotated_tbi     // channel: [val(meta), path(tbi)]
+        snv_vep_report            = PROCESS_SNVS.out.vep_report            // channel: [val(meta), val(process), val(tool), path(html)]
         snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
         snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -178,19 +178,29 @@ workflow ONCOREFINER {
         )
 
     emit:
-        cadd_annotated_vcf        = PROCESS_SNVS.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
-        cadd_annotated_tbi        = PROCESS_SNVS.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
+        cadd_annotated_vcf        = PROCESS_SNVS.out.cadd_annotated_vcf        // channel: [val(meta), path(vcf)]
+        cadd_annotated_tbi        = PROCESS_SNVS.out.cadd_annotated_tbi        // channel: [val(meta), path(tbi)]
         multiqc_report            = MULTIQC.out.report.toList()            // channel: /path/to/multiqc_report.html
-        snv_clinical_filtered_vcf = PROCESS_SNVS.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
-        snv_clinical_filtered_tbi = PROCESS_SNVS.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
+        snv_clinical_filtered_vcf = PROCESS_SNVS.out.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
+        snv_clinical_filtered_tbi = PROCESS_SNVS.out.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
         snv_vcfanno_vcf           = PROCESS_SNVS.out.vcfanno_vcf           // channel: [val(meta), path(vcf)]
         snv_vcfanno_tbi           = PROCESS_SNVS.out.vcfanno_tbi           // channel: [val(meta), path(vcf.tbi)]
-        snv_vep_annotated_vcf     = PROCESS_SNVS.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
-        snv_vep_annotated_tbi     = PROCESS_SNVS.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
-        snv_vep_report            = PROCESS_SNVS.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        snv_vep_annotated_vcf     = PROCESS_SNVS.out.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
+        snv_vep_annotated_tbi     = PROCESS_SNVS.out.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
+        snv_vep_report            = PROCESS_SNVS.out.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
         snv_research_filtered_vcf = PROCESS_SNVS.out.research_filtered_vcf // channel: [val(meta), path(vcf)]
         snv_research_filtered_tbi = PROCESS_SNVS.out.research_filtered_tbi // channel: [val(meta), path(vcf.tbi)]
+        sv_clinical_filtered_vcf  = PROCESS_SVS.out.clinical_filtered_vcf     // channel: [val(meta), path(vcf)]
+        sv_clinical_filtered_tbi  = PROCESS_SVS.out.clinical_filtered_tbi     // channel: [val(meta), path(tbi)]
+        sv_vep_annotated_vcf      = PROCESS_SVS.out.vep_annotated_vcf         // channel: [val(meta), path(vcf)]
+        sv_vep_annotated_tbi      = PROCESS_SVS.out.vep_annotated_tbi         // channel: [val(meta), path(tbi)]
+        sv_vep_report             = PROCESS_SVS.out.vep_report                // channel: [val(meta), val(process), val(tool), path(html)]
+        sv_svdb_vcf               = PROCESS_SVS.out.svdb_vcf                  // channel: [val(meta), path(vcf)]
+        sv_research_filtered_vcf  = PROCESS_SVS.out.research_filtered_vcf     // channel: [val(meta), path(vcf)]
+        sv_research_filtered_tbi  = PROCESS_SVS.out.research_filtered_tbi     // channel: [val(meta), path(tbi)]
+
         versions                  = ch_versions                            // channel: [ path(versions.yml) ]
+
 
 }
 


### PR DESCRIPTION
### Added

- Emit block with files to publish to:
	- `GENERATE_CYTOSURE_FILES` subworkflow.
	- `PROCESS_SVS` subworkflow.
	- `ONCOREFINER` workflow.

### Changed

-

### Fixed

-

### Removed

-
