### PR TITLE
fix: enforce same vep annotation for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#72](https://github.com/Clinical-Genomics/oncorefiner/pull/72) Added subworkflow test to `PREPARE_REFERENCES`
 - [#82](https://github.com/Clinical-Genomics/oncorefiner/pull/82) Add index files for SNV clinical and research filtered vcfs
 - [#90](https://github.com/Clinical-Genomics/oncorefiner/pull/90) Fixed bug in `GENERATE_CYTOSURE` and `PROCESS_SNVs`: updated test meta to be `subject_a` and input to contain tbi.
+- [#95](https://github.com/Clinical-Genomics/oncorefiner/pull/95) Fixed so VEP annotates in the same order for tests in `PROCESS_SVs`.
 
 ### `Dependencies`
 

--- a/subworkflows/local/process_svs/tests/main.nf.test
+++ b/subworkflows/local/process_svs/tests/main.nf.test
@@ -7,7 +7,7 @@ nextflow_workflow {
     tag "subworkflows"
     tag "process_svs"
 
-setup {
+    setup {
         run("UNTAR", alias: "UNTAR_VEP_CACHE") {
             script "modules/nf-core/untar/main.nf"
             process {

--- a/subworkflows/local/process_svs/tests/main.nf.test
+++ b/subworkflows/local/process_svs/tests/main.nf.test
@@ -2,25 +2,27 @@ nextflow_workflow {
 
     name "Test subworkflow Process Structural Variants (PROCESS_SVS)"
     script "../main.nf"
+    config "./nextflow.config"
     workflow "PROCESS_SVS"
     tag "subworkflows"
     tag "process_svs"
 
-    setup {
+
+    test("with tumor-normal data") {
+
+        setup {
         run("UNTAR", alias: "UNTAR_VEP_CACHE") {
             script "modules/nf-core/untar/main.nf"
             process {
                 """
                 input[0] = channel.of([
                     [id:'vep_cache'],
-                    file(params.pipelines_testdata_base_path + 'reference/vep_cache_and_plugins.tar.gz', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/vep_cache.tar.gz', checkIfExists: true)
                 ])
                 """
+                }
             }
         }
-    }
-
-    test("with tumor-normal data") {
 
         when {
             params {
@@ -32,35 +34,31 @@ nextflow_workflow {
                 input[0] = channel.empty()
                 input[1] = channel.of([
                     ['type':'tumor'],
-                    file(params.pipelines_testdata_base_path + 'testdata/subject_a.tumor.redux.bam', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'testdata/subject_a.tumor.redux.bam.bai', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/subject_a.tumor.redux.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/subject_a.tumor.redux.bam.bai', checkIfExists: true)
                 ])
                 input[2] = channel.of([
                     [id:'subject_a'],
-                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/tumor_normal/subject_a.tumor.purple.sv.vcf.gz', checkIfExists: true)
                 ])
                 input[3] = channel.of([
                     [id:'subject_a'],
-                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz.tbi', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/tumor_normal/subject_a.tumor.purple.sv.vcf.gz.tbi', checkIfExists: true)
                 ])
                 input[4] = channel.of(
-                    file(params.pipelines_testdata_base_path + 'reference/svdb_querydb_files.csv', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/svdb_querydb_files.csv', checkIfExists: true)
                 )
-                input[5] = "GRCh37"
+                input[5] = "GRCh38"
                 input[6] = "homo_sapiens"
-                input[7] = 107
+                input[7] = 115
                 input[8] = UNTAR_VEP_CACHE.out.untar.map{ _meta, files -> [files]}.collect()
                 input[9] = channel.of([
                     [id:'reference'],
-                    file(params.pipelines_testdata_base_path + 'reference/reference.fasta', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/GRCh38_masked_exclusions_alts_hlas_subset.fasta', checkIfExists: true)
                 ])
                 input[10] = channel.of([
-                    file(params.pipelines_testdata_base_path + 'reference/LoFtool_scores.txt', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_indel_-v1.3-.vcf.gz', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_snv_-v1.3-.vcf.gz', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/pLI_values.txt', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_indel_-v1.3-.vcf.gz.tbi', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_snv_-v1.3-.vcf.gz.tbi', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/LoFtool_scores.txt', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/pLI_values.txt', checkIfExists: true)
                 ])
                 """
             }

--- a/subworkflows/local/process_svs/tests/main.nf.test
+++ b/subworkflows/local/process_svs/tests/main.nf.test
@@ -7,22 +7,21 @@ nextflow_workflow {
     tag "subworkflows"
     tag "process_svs"
 
-
-    test("with tumor-normal data") {
-
-        setup {
+setup {
         run("UNTAR", alias: "UNTAR_VEP_CACHE") {
             script "modules/nf-core/untar/main.nf"
             process {
                 """
                 input[0] = channel.of([
                     [id:'vep_cache'],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/vep_cache.tar.gz', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/vep_cache_and_plugins.tar.gz', checkIfExists: true)
                 ])
                 """
-                }
             }
         }
+    }
+
+    test("with tumor-normal data") {
 
         when {
             params {
@@ -34,31 +33,35 @@ nextflow_workflow {
                 input[0] = channel.empty()
                 input[1] = channel.of([
                     ['type':'tumor'],
-                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/subject_a.tumor.redux.bam', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/subject_a.tumor.redux.bam.bai', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/subject_a.tumor.redux.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/subject_a.tumor.redux.bam.bai', checkIfExists: true)
                 ])
                 input[2] = channel.of([
                     [id:'subject_a'],
-                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/tumor_normal/subject_a.tumor.purple.sv.vcf.gz', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz', checkIfExists: true)
                 ])
                 input[3] = channel.of([
                     [id:'subject_a'],
-                    file(params.pipelines_testdata_base_path + 'testdata/GRCh38/tumor_normal/subject_a.tumor.purple.sv.vcf.gz.tbi', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'testdata/tumor_normal/subject_a.tumor.purple.sv.vcf.gz.tbi', checkIfExists: true)
                 ])
                 input[4] = channel.of(
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/svdb_querydb_files.csv', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/svdb_querydb_files.csv', checkIfExists: true)
                 )
-                input[5] = "GRCh38"
+                input[5] = "GRCh37"
                 input[6] = "homo_sapiens"
-                input[7] = 115
+                input[7] = 107
                 input[8] = UNTAR_VEP_CACHE.out.untar.map{ _meta, files -> [files]}.collect()
                 input[9] = channel.of([
                     [id:'reference'],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/GRCh38_masked_exclusions_alts_hlas_subset.fasta', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/reference.fasta', checkIfExists: true)
                 ])
                 input[10] = channel.of([
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/LoFtool_scores.txt', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh38/pLI_values.txt', checkIfExists: true)
+                    file(params.pipelines_testdata_base_path + 'reference/LoFtool_scores.txt', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_indel_-v1.3-.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_snv_-v1.3-.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/pLI_values.txt', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_indel_-v1.3-.vcf.gz.tbi', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/spliceai_21_scores_raw_snv_-v1.3-.vcf.gz.tbi', checkIfExists: true)
                 ])
                 """
             }

--- a/subworkflows/local/process_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/process_svs/tests/main.nf.test.snap
@@ -18,28 +18,28 @@
             [
                 [
                     "subject_a_clinical.vcf.gz",
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "aca08367cdefe343d4d2a8c10a8633be"
                 ],
                 [
                     "subject_a_research.vcf.gz",
-                    "5586f18ef999bffe0b0b9cc1831f7ff3"
+                    "5555fa260ad068c6b0c1704ac6ac933"
                 ],
                 [
                     "subject_a_svdbquery_vep.vcf.gz",
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "aca08367cdefe343d4d2a8c10a8633be"
                 ]
             ],
             [
                 [
                     "subject_a_vcfdb_query.vcf",
-                    "18444b35d848a5ac45a1576967bd928d"
+                    "2e990ef9ab2c6ca2da8e497de0b4415"
                 ]
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-23T09:50:04.660976"
+        "timestamp": "2026-05-06T15:54:01.812819"
     }
 }

--- a/subworkflows/local/process_svs/tests/nextflow.config
+++ b/subworkflows/local/process_svs/tests/nextflow.config
@@ -1,0 +1,17 @@
+process {
+    withName: 'ENSEMBLVEP_VEP' {
+        ext.args = { [
+            '--dir_cache cache',
+            '--dir_plugins cache/Plugins',
+            '--plugin pLI,pLI_values.txt',
+            '--appris --biotype --buffer_size 100 --canonical --cache --ccds',
+            '--compress_output bgzip --distance 5000 --domains',
+            '--exclude_predicted --force_overwrite --format vcf',
+            '--hgvs --humdiv --max_sv_size 248956422 --merged',
+            '--no_progress --numbers --per_gene --polyphen p',
+            '--protein --offline --regulatory --sift p',
+            '--symbol --tsl --uniprot --vcf',
+            '--pick --pick_order mane_select,mane_plus_clinical,canonical,appris,tsl,biotype,ccds,rank,length,ensembl,refseq'
+        ].join(' ') }
+    }
+}

--- a/subworkflows/local/process_svs/tests/nextflow.config
+++ b/subworkflows/local/process_svs/tests/nextflow.config
@@ -1,5 +1,5 @@
 process {
-    withName: 'ENSEMBLVEP_VEP' {
+    withName: '.*ENSEMBLVEP_VEP*.' {
         ext.args = { [
             '--dir_cache cache',
             '--dir_plugins cache/Plugins',

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -34,7 +34,7 @@ process {
         time: '1.h'
     ]
 
-    withName: 'ENSEMBLVEP_VEP' {
+    withName: '.*:PROCESS_SVS:ENSEMBLVEP_VEP' {
         ext.args = { [
             '--dir_cache cache',
             '--dir_plugins cache/Plugins',

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -12,7 +12,7 @@ params {
     config_profile_name          = 'Test profile'
     config_profile_description   = 'Minimal test dataset to check pipeline function'
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/60a4ba9429f86a715fd07000b348cc6433c1c5d4/'
 }
 
 
@@ -33,4 +33,20 @@ process {
         memory: '15.GB',
         time: '1.h'
     ]
+
+    withName: 'ENSEMBLVEP_VEP' {
+        ext.args = { [
+            '--dir_cache cache',
+            '--dir_plugins cache/Plugins',
+            '--plugin pLI,pLI_values.txt',
+            '--appris --biotype --buffer_size 100 --canonical --cache --ccds',
+            '--compress_output bgzip --distance 5000 --domains',
+            '--exclude_predicted --force_overwrite --format vcf',
+            '--hgvs --humdiv --max_sv_size 248956422 --merged',
+            '--no_progress --numbers --per_gene --polyphen p',
+            '--protein --offline --regulatory --sift p',
+            '--symbol --tsl --uniprot --vcf',
+            '--pick --pick_order mane_select,mane_plus_clinical,canonical,appris,tsl,biotype,ccds,rank,length,ensembl,refseq'
+        ].join(' ') }
+    }
 }

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -12,7 +12,7 @@ params {
     config_profile_name          = 'Test profile'
     config_profile_description   = 'Minimal test dataset to check pipeline function'
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/60a4ba9429f86a715fd07000b348cc6433c1c5d4/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Clinical-Genomics/test-datasets/a0b1a0c806be5823377671bba35eb22f2e28956d/'
 }
 
 


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/MTP-oncoflow/issues/48

### Changed

- Added nextflow.config with VEP --pick --pick_order arguments to PROCESS_SVs subworkflow test in order to enforce same order every time (for compatibility with variantsMD5)

