### PR TITLE
Add `genmod_score_config` param

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -47,6 +47,7 @@ Annotation related files and options required for the workflow.
 | `vcfanno_toml` | Path to the vcfanno toml file. <details><summary>Help</summary><small>If no toml is passed, default configurations will be used according to genome build within the context of the pipeline.</small></details>| `string` |  |  |  |
 | `vcfanno_lua` | Path to the vcfanno lua file. <details><summary>Help</summary><small>Custom operations file (lua). For use when the built-in ops don't supply the needed reduction.</small></details>| `string` |  |  |  |
 | `svdb_query_dbs` | Databases used for structural variant annotation in vcf format. <details><summary>Help</summary><small>Path to comma-separated file containing information about the databases used for structural variant annotation.</small></details>| `string` |  |  |  |
+| `genmod_score_config` | Path to genmod score configuration file (rank model). | `string` |  |  |  |
 
 ## Institutional config options
 

--- a/main.nf
+++ b/main.nf
@@ -37,6 +37,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     val_bai_tumor               // string:  [optional]  path to BAI file for the tumor sample
     val_cadd_prescored_indels   // string:  [optional]  path to CADD prescored indels file
     val_cadd_resources          // string:  [optional]  path to CADD resources directory
+    val_genmod_score_config     // string:  [optional]  path to Genmod config file
     val_genome                  // string:  [optional]  genome assembly (e.g. "GRCh38")
     val_genome_fasta            // string:  [optional]  path to genome fasta file
     val_genome_fai              // string:  [optional]  path to genome fasta index file
@@ -134,6 +135,9 @@ workflow CLINICALGENOMICS_ONCOREFINER {
     ch_sv_dbs            = val_svdb_query_dbs    ? channel.fromPath(val_svdb_query_dbs)
                                                  : channel.empty()
 
+    // Input for genmod_score
+    ch_genmod_score_config = val_genmod_score_config ? channel.fromPath(val_genmod_score_config).map { it -> [[id:'genmod_score_config'], it] }.collect()
+                                                     : channel.empty()
 
     ONCOREFINER (
         samplesheet,
@@ -142,6 +146,7 @@ workflow CLINICALGENOMICS_ONCOREFINER {
         ch_cadd_header,
         ch_cadd_prescored_indels,
         ch_cadd_resources,
+        ch_genmod_score_config,
         ch_genome_fasta,
         ch_genome_fai,
         ch_snv_vcf,
@@ -211,6 +216,7 @@ workflow {
         params.bai_tumor,
         params.cadd_prescored_indels,
         params.cadd_resources,
+        params.genmod_score_config,
         params.genome,
         params.fasta,
         params.fai,

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,7 +42,7 @@ params {
     svdb_query_dbs              = null
 
     // Genmod
-    genmod_score_config                = null
+    genmod_score_config         = null
 
     // References
     fasta                       = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,6 +41,9 @@ params {
     // SVDB
     svdb_query_dbs              = null
 
+    // Genmod
+    genmod_score_config                = null
+
     // References
     fasta                       = null
     fai                         = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -223,6 +223,13 @@
                     "help_text": "Path to comma-separated file containing information about the databases used for structural variant annotation.",
                     "pattern": "^\\S+\\.(csv|tsv|json|yaml|yml)$",
                     "schema": "assets/svdb_query_vcf_schema.json"
+                },
+                "genmod_score_config": {
+                    "type": "string",
+                    "description": "Path to genmod score configuration file (rank model).",
+                    "format": "file-path",
+                    "pattern": "^\\S+\\.(ini)$",
+                    "exists": true
                 }
             }
         },

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -28,6 +28,7 @@ workflow PROCESS_SNVS {
         ch_cadd_header           // channel: [optional]  [val(meta), path(header_file)]
         ch_cadd_prescored_indels // channel: [optional]  [val(meta), path(dir)]
         ch_cadd_resources        // channel: [optional]  [val(meta), path(dir)]
+        ch_genmod_score_config   // channel: [optional]  [val(meta), path(ini)]
         ch_snv_vcf               // channel: [optional]  [val(meta), path(vcf)]
         ch_snv_vcf_tbi           // channel: [optional]  [val(meta), path(vcf.tbi)]
         ch_vcfanno_extra         // channel: [optional]  [path(extra_file1), path(extra_file2), ...]

--- a/workflows/oncorefiner.nf
+++ b/workflows/oncorefiner.nf
@@ -43,6 +43,7 @@ workflow ONCOREFINER {
         ch_cadd_header           // channel: [mandatory] [path(txt)]
         ch_cadd_prescored_indels // channel: [optional]  [val(meta), path(dir)]
         ch_cadd_resources        // channel: [optional]  [val(meta), path(dir)]
+        ch_genmod_score_config   // channel: [optional]  [val(meta), path(ini)]
         ch_genome_fasta          // channel: [optional]  [val(meta), path(fasta)]
         ch_genome_fai            // channel: [optional]  [val(meta), path(fai)]
         ch_snv_vcf               // channel: [optional]  [val(meta), path(vcf)]
@@ -74,6 +75,7 @@ workflow ONCOREFINER {
             ch_cadd_header,
             ch_cadd_prescored_indels,
             ch_cadd_resources,
+            ch_genmod_score_config,
             ch_snv_vcf,
             ch_snv_vcf_tbi,
             ch_vcfanno_extra,


### PR DESCRIPTION
### Added

- Add `genmod_score_config` param to be used by  'vcf_annotate_score_genmod' subworkflow in https://github.com/Clinical-Genomics/oncorefiner/pull/97.