### PR TITLE
feat: Add `genmod_score_config` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#59](https://github.com/Clinical-Genomics/oncorefiner/pull/59) Added `ANNOTATE_CADD` subworkflow with following test (stub only), for CADD scoring of InDels, used in `PROCESS_SNVS`.
 - [#69](https://github.com/Clinical-Genomics/oncorefiner/pull/69) Added `tumor_normal` config file, used by the default test profile.
 - [#69](https://github.com/Clinical-Genomics/oncorefiner/pull/69) Added `tumor_only` config file, profile and pipeline test and snapshot.
+- [#99](https://github.com/Clinical-Genomics/oncorefiner/pull/99) Added `genmod_score_config` parameter.
 
 ### `Changed`
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -47,6 +47,7 @@ Annotation related files and options required for the workflow.
 | `vcfanno_toml` | Path to the vcfanno toml file. <details><summary>Help</summary><small>If no toml is passed, default configurations will be used according to genome build within the context of the pipeline.</small></details>| `string` |  |  |  |
 | `vcfanno_lua` | Path to the vcfanno lua file. <details><summary>Help</summary><small>Custom operations file (lua). For use when the built-in ops don't supply the needed reduction.</small></details>| `string` |  |  |  |
 | `svdb_query_dbs` | Databases used for structural variant annotation in vcf format. <details><summary>Help</summary><small>Path to comma-separated file containing information about the databases used for structural variant annotation.</small></details>| `string` |  |  |  |
+| `genmod_score_config` | Path to genmod score configuration file (rank model). | `string` |  |  |  |
 
 ## Institutional config options
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,6 +41,9 @@ params {
     // SVDB
     svdb_query_dbs              = null
 
+    // Genmod
+    genmod_score_config         = null
+
     // References
     fasta                       = null
     fai                         = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -223,6 +223,13 @@
                     "help_text": "Path to comma-separated file containing information about the databases used for structural variant annotation.",
                     "pattern": "^\\S+\\.(csv|tsv|json|yaml|yml)$",
                     "schema": "assets/svdb_query_vcf_schema.json"
+                },
+                "genmod_score_config": {
+                    "type": "string",
+                    "description": "Path to genmod score configuration file (rank model).",
+                    "format": "file-path",
+                    "pattern": "^\\S+\\.(ini)$",
+                    "exists": true
                 }
             }
         },


### PR DESCRIPTION
### Added

- Add `genmod_score_config` param to be used by  'vcf_annotate_score_genmod' subworkflow in https://github.com/Clinical-Genomics/oncorefiner/pull/97.