### PR TITLE
refactor: Change logic for `stable_path` in pipeline tests to exclude all vcf and index files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#87](https://github.com/Clinical-Genomics/oncorefiner/pull/87) Updated all testdata file paths to GRCh38 files, updated snapshot.
 - [#100](https://github.com/Clinical-Genomics/oncorefiner/pull/100) Template update for nf-core tools 4.0.2.
 - [#100](https://github.com/Clinical-Genomics/oncorefiner/pull/100) Changed minimum required nextflow version to 25.10.4.
-- [#106](https://github.com/Clinical-Genomics/oncorefiner/pull/106) Changed logic for `stable_path` in pipeline tests to exclude all vcf and index files. Removed individual entries for these files in the `tests/.nftignore`.
+- [#106](https://github.com/Clinical-Genomics/oncorefiner/pull/106) Changed logic for `stable_path` in pipeline tests to exclude all vcf and index files by default. Removed individual entries for these files in `tests/.nftignore`.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#87](https://github.com/Clinical-Genomics/oncorefiner/pull/87) Updated all testdata file paths to GRCh38 files, updated snapshot.
 - [#100](https://github.com/Clinical-Genomics/oncorefiner/pull/100) Template update for nf-core tools 4.0.2.
 - [#100](https://github.com/Clinical-Genomics/oncorefiner/pull/100) Changed minimum required nextflow version to 25.10.4.
+- [#106](https://github.com/Clinical-Genomics/oncorefiner/pull/106) Changed logic for `stable_path` in pipeline tests to exclude all vcf and index files. Removed individual entries for these files in the `tests/.nftignore`.
 
 ### `Fixed`
 

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,5 +9,6 @@ multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 multiqc/multiqc_data/multiqc_citations.txt
 pipeline_info/*.{html,json,txt,yml}
+process_svs/*.{vcf}
 vep/*.{html}
 alignments/*.{cram,crai}

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,6 +9,6 @@ multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 multiqc/multiqc_data/multiqc_citations.txt
 pipeline_info/*.{html,json,txt,yml}
-process_svs/*.{vcf}
 vep/*.{html}
+process_svs/*.{vcf}
 alignments/*.{cram,crai}

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,9 +9,5 @@ multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 multiqc/multiqc_data/multiqc_citations.txt
 pipeline_info/*.{html,json,txt,yml}
-vep/*.{vcf.gz,tbi,html}
-process_svs/*.{vcf,vcf.gz,tbi}
-clinical_filtering/*.{vcf.gz,tbi}
-vcfanno/*.{vcf.gz,tbi}
-research_filtering/*.{vcf,vcf.gz,tbi}
+vep/*.{html}
 alignments/*.{cram,crai}

--- a/tests/tumor_normal.nf.test
+++ b/tests/tumor_normal.nf.test
@@ -16,8 +16,8 @@ nextflow_pipeline {
         then {
             // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
-            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            // stable_path: All files in ${params.outdir}/ with stable content (excludes vcf and index files which are captured separately below)
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore', ignore: ['**/*.vcf.gz*'])
             // all_vcf_files: All vcf files - can have unstable variants and/or unstable headers
             def all_vcf_files    = getAllFilesFromDir(params.outdir, include: ['**/*.vcf.gz'])
             // vcfs_with_stable_variants: Vcf files with stable variants - can be snapshot using variantsMD5

--- a/tests/tumor_only.nf.test
+++ b/tests/tumor_only.nf.test
@@ -17,8 +17,8 @@ nextflow_pipeline {
         then {
             // stable_name: All files + folders in ${params.outdir}/ with a stable name
             def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
-            // stable_path: All files in ${params.outdir}/ with stable content
-            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            // stable_path: All files in ${params.outdir}/ with stable content (excludes vcf and index files which are captured separately below)
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore', ignore: ['**/*.vcf.gz*'])
             // all_vcf_files: All vcf files - can have unstable variants and/or unstable headers
             def all_vcf_files = getAllFilesFromDir(params.outdir, include: ['**/*.vcf.gz'])
             // vcfs_with_stable_variants: Vcf files with stable variants - can be snapshot using variantsMD5


### PR DESCRIPTION
### Changed

- Logic for `stable_path` in pipeline tests to exclude all vcf and index files by default, so that `tests/.nftignore` does not have to be manually updated every time the logic for generating vcf files or their output directories are updated.
- Removed individual entries for these files in `tests/.nftignore`.