### PR TITLE
fix: Add genome parameter for `VCF2CYTOSURE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#90](https://github.com/Clinical-Genomics/oncorefiner/pull/90) Fixed bug in `GENERATE_CYTOSURE` and `PROCESS_SNVs`: updated test meta to be `subject_a` and input to contain tbi.
 - [#95](https://github.com/Clinical-Genomics/oncorefiner/pull/95) Fixed so VEP annotates in the same order for tests in `PROCESS_SVs`.
 - [#96](https://github.com/Clinical-Genomics/oncorefiner/pull/96) Moved custom test settings for `PROCESS_SNVS:BCFTOOLS_VIEW_*` to test configs.
-- [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Add extra argument `genome` for `VCF2CYTOSURE`, given from `params.genome_version_number`, to ensure the reference genome used for the process matches the given input data.
+- [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Added `genome` argument for `VCF2CYTOSURE`, given by `params.genome_version_number`, to ensure the reference genome used for the process matches the given input data.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#90](https://github.com/Clinical-Genomics/oncorefiner/pull/90) Fixed bug in `GENERATE_CYTOSURE` and `PROCESS_SNVs`: updated test meta to be `subject_a` and input to contain tbi.
 - [#95](https://github.com/Clinical-Genomics/oncorefiner/pull/95) Fixed so VEP annotates in the same order for tests in `PROCESS_SVs`.
 - [#96](https://github.com/Clinical-Genomics/oncorefiner/pull/96) Moved custom test settings for `PROCESS_SNVS:BCFTOOLS_VIEW_*` to test configs.
-- [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Add genome parameter for `VCF2CYTOSURE`, parsed from `params.genome`.
+- [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Add extra argument `genome` for `VCF2CYTOSURE`, given from `params.genome_version_number`, to ensure the reference genome used for the process matches the given input data.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#90](https://github.com/Clinical-Genomics/oncorefiner/pull/90) Fixed bug in `GENERATE_CYTOSURE` and `PROCESS_SNVs`: updated test meta to be `subject_a` and input to contain tbi.
 - [#95](https://github.com/Clinical-Genomics/oncorefiner/pull/95) Fixed so VEP annotates in the same order for tests in `PROCESS_SVs`.
 - [#96](https://github.com/Clinical-Genomics/oncorefiner/pull/96) Moved custom test settings for `PROCESS_SNVS:BCFTOOLS_VIEW_*` to test configs.
+- [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Add genome parameter for `VCF2CYTOSURE`, parsed from `params.genome`.
 
 ### `Dependencies`
 

--- a/conf/subworkflows/generate_cytosure_files.config
+++ b/conf/subworkflows/generate_cytosure_files.config
@@ -34,7 +34,7 @@ process {
             args = { [
                 "--bins 20",
                 "--sex ${params.sex}",
-                "--genome ${params.genome.replace("GRCh","")}" // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
+                "--genome ${params.genome_version_number}"
             ].join(' ') }
             prefix = { "${meta2.type}" }
         }

--- a/conf/subworkflows/generate_cytosure_files.config
+++ b/conf/subworkflows/generate_cytosure_files.config
@@ -34,7 +34,7 @@ process {
             args = { [
                 "--bins 20",
                 "--sex ${params.sex}",
-                "--genome ${params.genome.replace("GRCh","")}"
+                "--genome ${params.genome.replace("GRCh","")}" // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
             ].join(' ') }
             prefix = { "${meta2.type}" }
         }

--- a/conf/subworkflows/generate_cytosure_files.config
+++ b/conf/subworkflows/generate_cytosure_files.config
@@ -34,7 +34,7 @@ process {
             args = { [
                 "--bins 20",
                 "--sex ${params.sex}",
-                "--genome ${params.genome.replaceAll("[a-zA-Z]","")}" // Remove alphabetical characters from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
+                "--genome ${params.genome.replace("GRCh","")}"
             ].join(' ') }
             prefix = { "${meta2.type}" }
         }

--- a/conf/subworkflows/generate_cytosure_files.config
+++ b/conf/subworkflows/generate_cytosure_files.config
@@ -33,7 +33,8 @@ process {
         ext{
             args = { [
                 "--bins 20",
-                "--sex ${params.sex}"
+                "--sex ${params.sex}",
+                "--genome ${params.genome.replaceAll("[a-zA-Z]","")}" // Remove alphabetical characters from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
             ].join(' ') }
             prefix = { "${meta2.type}" }
         }

--- a/tests/tumor_normal.nf.test.snap
+++ b/tests/tumor_normal.nf.test.snap
@@ -83,8 +83,8 @@
                 "vep/subject_a_vep.vcf.gz_summary.html"
             ],
             [
-                "normal.cgh:md5,4d15de693be0db795e1b6b91b6e8d0bf",
-                "tumor.cgh:md5,2dfa8fdd26448127347045837c7cbf7c"
+                "normal.cgh:md5,1474d79c5254e4ecfdc9e15ce13d7916",
+                "tumor.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
             ],
             [
                 [
@@ -147,10 +147,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-05-27T11:42:36.625299",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-07T13:20:18.421691"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }

--- a/tests/tumor_only.nf.test.snap
+++ b/tests/tumor_only.nf.test.snap
@@ -80,7 +80,7 @@
                 "vep/subject_a_vep.vcf.gz_summary.html"
             ],
             [
-                "tumor.cgh:md5,ec06e9c9371636aba5e9717857e39e6b"
+                "tumor.cgh:md5,22c058183d93a767ee61d5319513dc39"
             ],
             [
                 [
@@ -143,10 +143,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-05-27T11:44:59.964764",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-07T13:21:17.061627"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/MTP-oncoflow/issues/68.

### Added

- Argument `genome` for `VCF2CYTOSURE`, given by `params.genome_version_number`, to ensure the reference genome used for the process matches the given input data.