### PR TITLE
feat: Add hidden `genome_version_number` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#59](https://github.com/Clinical-Genomics/oncorefiner/pull/59) Added `ANNOTATE_CADD` subworkflow with following test (stub only), for CADD scoring of InDels, used in `PROCESS_SNVS`.
 - [#69](https://github.com/Clinical-Genomics/oncorefiner/pull/69) Added `tumor_normal` config file, used by the default test profile.
 - [#69](https://github.com/Clinical-Genomics/oncorefiner/pull/69) Added `tumor_only` config file, profile and pipeline test and snapshot.
+- [#111](https://github.com/Clinical-Genomics/oncorefiner/pull/111) Added hidden `genome_version_number` parameter, parsed by default from `params.genome`.
 
 ### `Changed`
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -27,6 +27,7 @@ Reference genome related files and options required for the workflow.
 | Parameter | Description | Type | Default | Required | Hidden |
 |-----------|-----------|-----------|-----------|-----------|-----------|
 | `genome` | Name of the genome reference. (accepted: `GRCh38`\|`GRCh37`) <details><summary>Help</summary><small>Use this parameter to specify the ID for the reference genome used. This is then used to annotate the SV and SNV files e.g. `--genome GRCh38`.</small></details>| `string` | GRCh38 |  |  |
+| `genome_version_number` | Genome version number. By default parsed from `params.genome` by removing "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38"). (accepted: `37`\|`38`) | `integer` | 38 |  | True |
 | `fasta` | Path to FASTA genome file. <details><summary>Help</summary><small>If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.</small></details>| `string` |  |  |  |
 | `fai` | Path to FASTA genome index file. <details><summary>Help</summary><small>If none provided, will be generated automatically from the FASTA reference</small></details>| `string` |  |  |  |
 | `cadd_prescored_indels` | Path to a directory containing prescored indels for CADD. <details><summary>Help</summary><small>This folder contains the compressed files and indexes that would otherwise be in data/prescored folder as described in https://github.com/kircherlab/CADD-scripts/#manual-installation.</small></details>| `string` |  |  |  |

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
     fasta                       = null
     fai                         = null
     genome                      = 'GRCh38'
-    genome_version_number       = params.genome.replace("GRCh","") // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
+    genome_version_number       = params.genome.replace("GRCh","") as Integer // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
     species                     = 'homo_sapiens'
 
     // MultiQC options

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,7 @@ params {
     fasta                       = null
     fai                         = null
     genome                      = 'GRCh38'
+    genome_version_number       = params.genome.replace("GRCh","") // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
     species                     = 'homo_sapiens'
 
     // MultiQC options

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
     fasta                       = null
     fai                         = null
     genome                      = 'GRCh38'
-    genome_version_number       = params.genome.replace("GRCh","") as Integer // Remove "GRCh" from genome name to obtain only the version number (e.g. "GRCh38" -> "38")
+    genome_version_number       = params.genome.replace("GRCh","") as Integer // Remove "GRCh" from the genome name to obtain only the version number (e.g. "GRCh38" -> "38").
     species                     = 'homo_sapiens'
 
     // MultiQC options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -110,6 +110,13 @@
                     "default": "GRCh38",
                     "enum": ["GRCh38", "GRCh37"]
                 },
+                "genome_version_number": {
+                    "type": "integer",
+                    "default": 38,
+                    "hidden": true,
+                    "description": "Genome version number. By default parsed from `params.genome` by removing \"GRCh\" from genome name to obtain only the version number (e.g. \"GRCh38\" -> \"38\").",
+                    "enum": [37, 38]
+                },
                 "fasta": {
                     "type": "string",
                     "format": "file-path",


### PR DESCRIPTION
Part of https://github.com/Clinical-Genomics/MTP-oncoflow/issues/68.

### Added

- Hidden `genome_version_number` parameter parsed from params.genome by removing "GRCh" from the genome name to obtain only the version number (e.g. "GRCh38" -> "38"). This is necessary to provide config settings to fix the bug in the issue above.
