### PR TITLE
fix: Update `GENERATE_CYTOSURE_FILES` subworkflow test snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#95](https://github.com/Clinical-Genomics/oncorefiner/pull/95) Fixed so VEP annotates in the same order for tests in `PROCESS_SVs`.
 - [#96](https://github.com/Clinical-Genomics/oncorefiner/pull/96) Moved custom test settings for `PROCESS_SNVS:BCFTOOLS_VIEW_*` to test configs.
 - [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110) Added `genome` argument for `VCF2CYTOSURE`, given by `params.genome_version_number`, to ensure the reference genome used for the process matches the given input data.
+- [#116](https://github.com/Clinical-Genomics/oncorefiner/pull/116) Updated `GENERATE_CYTOSURE_FILES` subworkflow test snapshot in sequence of [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110).
 
 ### `Dependencies`
 

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
@@ -8,14 +8,14 @@
             [
                 [
                     "tumor.cgh",
-                    "2dfa8fdd26448127347045837c7cbf7c"
+                    "09c4fba0b534f86fc176fe2ccf00820d"
                 ]
             ]
         ],
+        "timestamp": "2026-06-01T10:51:52.862763",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-04-28T14:37:18.83334"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/MTP-oncoflow/issues/71.

### Fixed

- Updated `GENERATE_CYTOSURE_FILES` subworkflow test snapshot. The changes introduced in https://github.com/Clinical-Genomics/oncorefiner/pull/110 result in the generation of a modified output file for the subworkflow. However, for some unknown reason, the test for this subworkflow was either not triggered or incorrectly set as passed in the previous PR but caused now fails in more recent PRs.