### PR TITLE
fix: output SNV `research_filtered_vcf` after annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#116](https://github.com/Clinical-Genomics/oncorefiner/pull/116) Updated `GENERATE_CYTOSURE_FILES` subworkflow test snapshot in sequence of [#110](https://github.com/Clinical-Genomics/oncorefiner/pull/110).
 - [#123](https://github.com/Clinical-Genomics/oncorefiner/pull/123) Changed the subworkflow test when untarring is needed in `PREPARE_REFERENCES` to check `workflow.out.vep_resources` instead of `params.outdir`
 - [#129](https://github.com/Clinical-Genomics/oncorefiner/pull/129) Changed the extra arguments `extra_args_*` to default to '' instead of null and removed empty `extra_args_snv_vep` in `test_base.config`
+- [#130](https://github.com/Clinical-Genomics/oncorefiner/pull/130) Changed output logic for `PROCESS_SNVS` to output the `research_filtered_vcf` file after annotation with vep.
 
 ### `Dependencies`
 

--- a/subworkflows/local/process_snvs/main.nf
+++ b/subworkflows/local/process_snvs/main.nf
@@ -107,13 +107,13 @@ workflow PROCESS_SNVS {
             ch_vep_extra_files
         )
 
+        // Output research vcf channel after annotation
+        ch_research_filtered_vcf = ENSEMBLVEP_VEP.out.vcf
+        ch_research_filtered_tbi = ENSEMBLVEP_VEP.out.tbi
+
         // Clinical Filtering
-        ENSEMBLVEP_VEP.out.vcf
-            .join(ENSEMBLVEP_VEP.out.tbi)
-            .map { meta, vcf, tbi ->
-                tuple(meta, vcf, tbi)
-                }
-            .set { ch_clinical_filtering_in }
+        ch_clinical_filtering_in = ch_research_filtered_vcf
+            .join(ch_research_filtered_tbi)
 
         BCFTOOLS_VIEW_CLINICAL(ch_clinical_filtering_in, [], [], [])
 
@@ -127,6 +127,6 @@ workflow PROCESS_SNVS {
     vep_annotated_vcf     = ENSEMBLVEP_VEP.out.vcf         // channel: [val(meta), path(vcf)]
     vep_annotated_tbi     = ENSEMBLVEP_VEP.out.tbi         // channel: [val(meta), path(tbi)]
     vep_report            = ENSEMBLVEP_VEP.out.report      // channel: [val(meta), val(process), val(tool), path(html)]
-    research_filtered_vcf = BCFTOOLS_VIEW_RESEARCH.out.vcf // channel: [val(meta), path(vcf)]
-    research_filtered_tbi = BCFTOOLS_VIEW_RESEARCH.out.tbi // channel: [val(meta), path(tbi)]
+    research_filtered_vcf = ch_research_filtered_vcf       // channel: [val(meta), path(vcf)]
+    research_filtered_tbi = ch_research_filtered_tbi       // channel: [val(meta), path(tbi)]
 }

--- a/subworkflows/local/process_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/process_snvs/tests/main.nf.test.snap
@@ -14,9 +14,9 @@
                     {
                         "id": "subject_a"
                     },
-                    "subject_a_research.vcf.gz",
+                    "subject_a_vep.vcf.gz",
                     ":variantsMD5,",
-                    "4cdfadaf39f5ed1c1d854226e6099c0d"
+                    "c7dae0b238f6b5f4bf91c0682824f474"
                 ],
                 [
                     {
@@ -46,7 +46,7 @@
                     {
                         "id": "subject_a"
                     },
-                    "subject_a_research.vcf.gz.tbi"
+                    "subject_a_vep.vcf.gz.tbi"
                 ],
                 [
                     {
@@ -70,11 +70,11 @@
                 ]
             ]
         ],
+        "timestamp": "2026-06-15T14:27:06.907156",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-07T10:45:33.948103"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "with tumor-normal data - stub": {
         "content": [
@@ -89,7 +89,7 @@
                     {
                         "id": "subject_a"
                     },
-                    "subject_a_research.vcf.gz"
+                    "subject_a_vep.vcf.gz"
                 ],
                 [
                     {
@@ -115,7 +115,7 @@
                     {
                         "id": "subject_a"
                     },
-                    "subject_a_research.vcf.gz.tbi"
+                    "subject_a_vep.vcf.gz.tbi"
                 ],
                 [
                     {
@@ -139,10 +139,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-06-15T14:27:47.993642",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-06-08T09:54:12.41387"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }

--- a/tests/tumor_normal.nf.test.snap
+++ b/tests/tumor_normal.nf.test.snap
@@ -61,8 +61,6 @@
                 "snv",
                 "snv/subject_a_clinical.vcf.gz",
                 "snv/subject_a_clinical.vcf.gz.tbi",
-                "snv/subject_a_research.vcf.gz",
-                "snv/subject_a_research.vcf.gz.tbi",
                 "snv/subject_a_vcfanno.vcf.gz",
                 "snv/subject_a_vcfanno.vcf.gz.tbi",
                 "snv/subject_a_vep.vcf.gz",
@@ -77,11 +75,11 @@
                 "vep/subject_a_svdbquery_vep_summary.html"
             ]
         ],
+        "timestamp": "2026-06-15T14:21:20.993278",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-06-08T09:56:55.147283"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "Tumor Normal analysis with '-profile test'": {
         "content": [
@@ -149,8 +147,6 @@
                 "snv",
                 "snv/subject_a_clinical.vcf.gz",
                 "snv/subject_a_clinical.vcf.gz.tbi",
-                "snv/subject_a_research.vcf.gz",
-                "snv/subject_a_research.vcf.gz.tbi",
                 "snv/subject_a_vcfanno.vcf.gz",
                 "snv/subject_a_vcfanno.vcf.gz.tbi",
                 "snv/subject_a_vep.vcf.gz",
@@ -182,10 +178,6 @@
                     "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=2, variantCount=103, phased=false, phasedAutodetect=false]"
                 ],
                 [
-                    "subject_a_research.vcf.gz",
-                    "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=2, variantCount=103, phased=false, phasedAutodetect=false]"
-                ],
-                [
                     "subject_a_vcfanno.vcf.gz",
                     "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=2, variantCount=103, phased=false, phasedAutodetect=false]"
                 ],
@@ -212,10 +204,6 @@
                     "c7dae0b238f6b5f4bf91c0682824f474"
                 ],
                 [
-                    "subject_a_research.vcf.gz",
-                    "4cdfadaf39f5ed1c1d854226e6099c0d"
-                ],
-                [
                     "subject_a_vcfanno.vcf.gz",
                     "f79b3dd00e3a53231a4bbd52ebcc6d1d"
                 ],
@@ -229,10 +217,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-06-15T14:20:11.938884",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
-        },
-        "timestamp": "2026-06-01T13:50:50.286939"
+        }
     }
 }

--- a/tests/tumor_only.nf.test.snap
+++ b/tests/tumor_only.nf.test.snap
@@ -63,8 +63,6 @@
                 "snv",
                 "snv/subject_a_clinical.vcf.gz",
                 "snv/subject_a_clinical.vcf.gz.tbi",
-                "snv/subject_a_research.vcf.gz",
-                "snv/subject_a_research.vcf.gz.tbi",
                 "snv/subject_a_vcfanno.vcf.gz",
                 "snv/subject_a_vcfanno.vcf.gz.tbi",
                 "snv/subject_a_vep.vcf.gz",
@@ -94,10 +92,6 @@
                     "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=1, variantCount=104, phased=false, phasedAutodetect=false]"
                 ],
                 [
-                    "subject_a_research.vcf.gz",
-                    "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=1, variantCount=104, phased=false, phasedAutodetect=false]"
-                ],
-                [
                     "subject_a_vcfanno.vcf.gz",
                     "VcfFile [chromosomes=[chr9, chr7, chr8, chrX, chr5, chr6, chr3, chr21, chr4, chr11, chr22, chr1, chr12, chr2, chr13, chr20, chr18, chr19, chr15, chr16, chr17], sampleCount=1, variantCount=104, phased=false, phasedAutodetect=false]"
                 ],
@@ -124,10 +118,6 @@
                     "96afd20d30255284c06a3fd505a1d466"
                 ],
                 [
-                    "subject_a_research.vcf.gz",
-                    "27194adc2bdd7b36168516d5c8e6e293"
-                ],
-                [
                     "subject_a_vcfanno.vcf.gz",
                     "e99aee3237070db74efee69d7a5d4be2"
                 ],
@@ -141,11 +131,11 @@
                 ]
             ]
         ],
+        "timestamp": "2026-06-15T14:23:07.735367",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
-        },
-        "timestamp": "2026-06-01T15:20:42.770358"
+        }
     },
     "Tumor only analysis with '-profile test_tumor_only' - stub": {
         "content": [
@@ -207,8 +197,6 @@
                 "snv",
                 "snv/subject_a_clinical.vcf.gz",
                 "snv/subject_a_clinical.vcf.gz.tbi",
-                "snv/subject_a_research.vcf.gz",
-                "snv/subject_a_research.vcf.gz.tbi",
                 "snv/subject_a_vcfanno.vcf.gz",
                 "snv/subject_a_vcfanno.vcf.gz.tbi",
                 "snv/subject_a_vep.vcf.gz",
@@ -222,10 +210,10 @@
                 "vep/subject_a_svdbquery_vep_summary.html"
             ]
         ],
+        "timestamp": "2026-06-15T14:24:08.415071",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-06-08T09:58:40.482421"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/MTP-oncoflow/issues/84.

### Changed

- Output logic for `PROCESS_SNVS` to output the `research_filtered_vcf` file after annotation with vep. The file name for this output is now given by vep, i.e. with prefix `${meta.id}_vep`.
