### PR TITLE
fix: Decouple `GENERATE_CYTOSURE_FILES` tests from pipeline configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#138](https://github.com/Clinical-Genomics/oncorefiner/pull/138) Changed indentation to consistently match the nf-core template.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/108) Updated `bcftools/view` module, also included in `genomic-medicine-sweden/vcf_annotate_score_genmod` subworkflow.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Changed `PROCESS_SNVS` output logic to return `ch_research_filtered_vcf/tbi` after scoring if this step is run. The file names for these outputs are then given by `VCF_ANNOTATE_SCORE_GENMOD:BCFTOOLS_VIEW`, i.e. with prefix `${meta.id}_genmod_score` as specified in the config file.
+- [#141](https://github.com/Clinical-Genomics/oncorefiner/pull/141) Refactored `GENERATE_CYTOSURE_FILES` to emit output from `VCF2CYTOSURE`.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#130](https://github.com/Clinical-Genomics/oncorefiner/pull/130) Changed output logic for `PROCESS_SNVS` to output the `research_filtered_vcf` file after annotation with vep.
 - [#131](https://github.com/Clinical-Genomics/oncorefiner/pull/131) Fixed strict Nextflow syntax compatibility in `ANNOTATE_CADD`
 - [#137](https://github.com/Clinical-Genomics/oncorefiner/pull/134) Fixed VEP able to run without `vep_plugin_files` parameter.
-- [#135](https://github.com/Clinical-Genomics/oncorefiner/pull/135) Fixed test for `GENERATE_CYTOSURE_FILES` so that it uses configurations from the test config and is independent from pipeline wide configuration.
+- [#135](https://github.com/Clinical-Genomics/oncorefiner/pull/135) Fixed test for `GENERATE_CYTOSURE_FILES` so that it states the necessary parameters for the test, uses configurations from the test config and is independent from pipeline wide configuration.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Added `genmod_score_config` parameter.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Added `genomic-medicine-sweden/vcf_annotate_score_genmod` subworkflow to `PROCESS_SNVS`.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Added `tests/optional_inputs_stub.nf.test` to test running the pipeline without optional inputs. Includes stub test for running the pipeline without providing the `genmod_score_config` parameter.
+- [#135](https://github.com/Clinical-Genomics/oncorefiner/pull/135) Added test config for `GENERATE_CYTOSURE_FILES`.
 
 ### `Changed`
 
@@ -102,6 +103,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#130](https://github.com/Clinical-Genomics/oncorefiner/pull/130) Changed output logic for `PROCESS_SNVS` to output the `research_filtered_vcf` file after annotation with vep.
 - [#131](https://github.com/Clinical-Genomics/oncorefiner/pull/131) Fixed strict Nextflow syntax compatibility in `ANNOTATE_CADD`
 - [#137](https://github.com/Clinical-Genomics/oncorefiner/pull/134) Fixed VEP able to run without `vep_plugin_files` parameter.
+- [#135](https://github.com/Clinical-Genomics/oncorefiner/pull/135) Fixed test for `GENERATE_CYTOSURE_FILES` so that it uses configurations from the test config and is independent from pipeline wide configuration.
 
 ### `Dependencies`
 

--- a/conf/subworkflows/generate_cytosure_files.config
+++ b/conf/subworkflows/generate_cytosure_files.config
@@ -16,20 +16,20 @@
 //
 
 process {
-    withName: '.*GENERATE_CYTOSURE_FILES:.*' {
+    withName: '.*:GENERATE_CYTOSURE_FILES:.*' {
         publishDir = [
             enabled: false,
         ]
     }
 
-    withName: '.*GENERATE_CYTOSURE_FILES:FILTER_VCF' {
+    withName: '.*:GENERATE_CYTOSURE_FILES:FILTER_VCF' {
         ext.args = { [
                 '--exclude \'SVTYPE=="SGL"\'',
                 '--output-type v',
             ].join(' ') }
     }
 
-    withName: '.*GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
+    withName: '.*:GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
         ext{
             args = { [
                 "--bins 20",

--- a/subworkflows/local/generate_cytosure_files/main.nf
+++ b/subworkflows/local/generate_cytosure_files/main.nf
@@ -37,4 +37,7 @@ workflow GENERATE_CYTOSURE_FILES {
         [[],[]],
         []
     )
+
+    emit:
+    VCF2CYTOSURE.out.cgh // channel: [val(meta), path(cgh)]
 }

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -3,6 +3,7 @@ nextflow_workflow {
     name "Test Workflow GENERATE_CYTOSURE_FILES"
     script "../main.nf"
     workflow "GENERATE_CYTOSURE_FILES"
+    config "./nextflow.config"
     tag "subworkflows"
     tag "generate_cytosure_files"
 

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -13,7 +13,9 @@ nextflow_workflow {
 
         when {
             params {
-                outdir = "$outputDir"
+                outdir                = "$outputDir"
+                genome_version_number = 38
+                sex                   = 'female'
             }
 
             workflow {
@@ -52,7 +54,9 @@ nextflow_workflow {
 
         when {
             params {
-                outdir = "$outputDir"
+                outdir                = "$outputDir"
+                genome_version_number = 38
+                sex                   = 'female'
             }
 
             workflow {

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -13,7 +13,6 @@ nextflow_workflow {
 
         when {
             params {
-                outdir                = "$outputDir"
                 genome_version_number = 38
                 sex                   = 'female'
             }
@@ -54,7 +53,6 @@ nextflow_workflow {
 
         when {
             params {
-                outdir                = "$outputDir"
                 genome_version_number = 38
                 sex                   = 'female'
             }

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -6,6 +6,8 @@ nextflow_workflow {
     tag "subworkflows"
     tag "generate_cytosure_files"
 
+    topics "versions"
+
     test("Alignment files from Tumor sample and somatic SV vcf files from TN test data") {
 
         when {
@@ -33,18 +35,11 @@ nextflow_workflow {
         }
 
         then {
-            // All directories and files in the output directory
-            def output_directories_and_files = getAllFilesFromDir(params.outdir, relative: true, includeDir: true)
-            // All files in the output directory
-            def output_files = getAllFilesFromDir(params.outdir)
-
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    // All directories and files in the output directory
-                    output_directories_and_files,
-                    // All files in the output directory with their md5 checksum
-                    output_files.collect { file -> [ file.getName(), path(file.toString()).md5 ] }
+                    topics,
+                    workflow.out
                 ).match() }
             )
         }
@@ -79,14 +74,11 @@ nextflow_workflow {
         }
 
         then {
-            // All directories and files in the output directory
-            def output_directories_and_files = getAllFilesFromDir(params.outdir, relative: true, includeDir: true)
-
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    // All directories and files in the output directory
-                    output_directories_and_files,
+                    topics,
+                    workflow.out
                 ).match() }
             )
         }

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
@@ -1,12 +1,37 @@
 {
     "Alignment files from Tumor sample and somatic SV vcf files from TN test data - stub": {
         "content": [
-            [
-                "vcf2cytosure",
-                "vcf2cytosure/tumor.cgh"
-            ]
+            {
+                "versions": [
+                    [
+                        "GENERATE_CYTOSURE_FILES:FILTER_VCF",
+                        "bcftools",
+                        "1.23.1"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:TIDDIT_COV",
+                        "tiddit",
+                        "3.9.5"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:VCF2CYTOSURE",
+                        "vcf2cytosure",
+                        "0.9.3"
+                    ]
+                ]
+            },
+            {
+                "0": [
+                    [
+                        {
+                            "id": "subject_a"
+                        },
+                        "tumor.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-06-01T16:48:40.967945",
+        "timestamp": "2026-06-18T11:49:43.567602",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
@@ -14,18 +39,37 @@
     },
     "Alignment files from Tumor sample and somatic SV vcf files from TN test data": {
         "content": [
-            [
-                "vcf2cytosure",
-                "vcf2cytosure/tumor.cgh"
-            ],
-            [
-                [
-                    "tumor.cgh",
-                    "09c4fba0b534f86fc176fe2ccf00820d"
+            {
+                "versions": [
+                    [
+                        "GENERATE_CYTOSURE_FILES:FILTER_VCF",
+                        "bcftools",
+                        "1.23.1"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:TIDDIT_COV",
+                        "tiddit",
+                        "3.9.5"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:VCF2CYTOSURE",
+                        "vcf2cytosure",
+                        "0.9.3"
+                    ]
                 ]
-            ]
+            },
+            {
+                "0": [
+                    [
+                        {
+                            "id": "subject_a"
+                        },
+                        "tumor.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-06-01T10:51:52.862763",
+        "timestamp": "2026-06-18T11:48:02.245565",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
@@ -26,12 +26,12 @@
                         {
                             "id": "subject_a"
                         },
-                        "tumor.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "tumor_vcf2cytosure.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-18T11:49:43.567602",
+        "timestamp": "2026-06-22T12:51:33.95931",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
@@ -64,12 +64,12 @@
                         {
                             "id": "subject_a"
                         },
-                        "tumor.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
+                        "tumor_vcf2cytosure.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-18T11:48:02.245565",
+        "timestamp": "2026-06-22T12:51:23.158033",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
@@ -26,12 +26,12 @@
                         {
                             "id": "subject_a"
                         },
-                        "tumor.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "tumor_vcf2cytosure.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-18T11:49:43.567602",
+        "timestamp": "2026-06-18T11:59:16.290516",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
@@ -64,12 +64,12 @@
                         {
                             "id": "subject_a"
                         },
-                        "tumor.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
+                        "tumor_vcf2cytosure.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-18T11:48:02.245565",
+        "timestamp": "2026-06-18T11:59:03.671133",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -1,0 +1,27 @@
+/*
+========================================================================================
+    Nextflow config file for running nf-test tests
+========================================================================================
+ Defines input files and everything required to run a fast and simple pipeline test.
+
+*/
+
+process {
+
+    withName: '.*GENERATE_CYTOSURE_FILES:FILTER_VCF' {
+        ext.args = { [
+                '--exclude \'SVTYPE=="SGL"\'',
+                '--output-type v',
+            ].join(' ') }
+    }
+
+    withName: '.*GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
+        ext.prefix = { "${meta2.type}" }
+        ext.args = { [
+                "--bins 20",
+                "--sex ${params.sex}",
+                "--genome ${params.genome_version_number}"
+            ].join(' ') }
+    }
+
+}

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -16,11 +16,11 @@ process {
             ].join(' ') }
     }
 
-    withName: 'GENERATE_CYTOSURE_FILES:TIDDIT_COV' {
+    withName: 'TIDDIT_COV' {
         ext.prefix = { "${meta.id}_tiddit_cov" }
     }
 
-    withName: 'GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
+    withName: 'VCF2CYTOSURE' {
         ext.prefix = { "${meta2.type}_vcf2cytosure" }
         ext.args = { [
                 "--bins 20",

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -7,16 +7,20 @@
 */
 
 process {
-
     withName: '.*GENERATE_CYTOSURE_FILES:FILTER_VCF' {
+        ext.prefix = { "${meta.id}_filter_vcf" }
         ext.args = { [
                 '--exclude \'SVTYPE=="SGL"\'',
                 '--output-type v',
             ].join(' ') }
     }
 
+    withName: '.*GENERATE_CYTOSURE_FILES:TIDDIT_COV' {
+        ext.prefix = { "${meta.id}_tiddit_cov" }
+    }
+
     withName: '.*GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
-        ext.prefix = { "${meta2.type}" }
+        ext.prefix = { "${meta2.id}_${meta2.type}_vcf2cytosure" }
         ext.args = { [
                 "--bins 20",
                 "--sex ${params.sex}",

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -8,7 +8,7 @@
 
 process {
 
-    withName: 'GENERATE_CYTOSURE_FILES:FILTER_VCF' {
+    withName: 'FILTER_VCF' {
         ext.prefix = { "${meta.id}_filter_vcf" }
         ext.args = { [
                 "--exclude 'SVTYPE==\"SGL\"'",

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -7,10 +7,11 @@
 */
 
 process {
+
     withName: '.*GENERATE_CYTOSURE_FILES:FILTER_VCF' {
         ext.prefix = { "${meta.id}_filter_vcf" }
         ext.args = { [
-                '--exclude \'SVTYPE=="SGL"\'',
+                "--exclude 'SVTYPE==\"SGL\"'",
                 '--output-type v',
             ].join(' ') }
     }

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -8,7 +8,7 @@
 
 process {
 
-    withName: '.*GENERATE_CYTOSURE_FILES:FILTER_VCF' {
+    withName: 'GENERATE_CYTOSURE_FILES:FILTER_VCF' {
         ext.prefix = { "${meta.id}_filter_vcf" }
         ext.args = { [
                 "--exclude 'SVTYPE==\"SGL\"'",
@@ -16,11 +16,11 @@ process {
             ].join(' ') }
     }
 
-    withName: '.*GENERATE_CYTOSURE_FILES:TIDDIT_COV' {
+    withName: 'GENERATE_CYTOSURE_FILES:TIDDIT_COV' {
         ext.prefix = { "${meta.id}_tiddit_cov" }
     }
 
-    withName: '.*GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
+    withName: 'GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
         ext.prefix = { "${meta2.type}_vcf2cytosure" }
         ext.args = { [
                 "--bins 20",

--- a/subworkflows/local/generate_cytosure_files/tests/nextflow.config
+++ b/subworkflows/local/generate_cytosure_files/tests/nextflow.config
@@ -21,7 +21,7 @@ process {
     }
 
     withName: '.*GENERATE_CYTOSURE_FILES:VCF2CYTOSURE' {
-        ext.prefix = { "${meta2.id}_${meta2.type}_vcf2cytosure" }
+        ext.prefix = { "${meta2.type}_vcf2cytosure" }
         ext.args = { [
                 "--bins 20",
                 "--sex ${params.sex}",


### PR DESCRIPTION
Part of: https://github.com/Clinical-Genomics/CancerBioInfo/issues/144

### Added

- Test config for `GENERATE_CYTOSURE_FILES` with configuration for all subworkflow processes.

### Fixed

- `conf/subworkflows/generate_cytosure_files.config` so all processes regex string start with `.*:` to make sure these settings only apply for pipeline runs.
- Test for `GENERATE_CYTOSURE_FILES` so that it states the necessary parameters for the test, uses configurations from the test config and is independent from pipeline wide configuration.