### PR TITLE
refactor: `GENERATE_CYTOSURE_FILES` to emit workflow outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#138](https://github.com/Clinical-Genomics/oncorefiner/pull/138) Changed indentation to consistently match the nf-core template.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/108) Updated `bcftools/view` module, also included in `genomic-medicine-sweden/vcf_annotate_score_genmod` subworkflow.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Changed `PROCESS_SNVS` output logic to return `ch_research_filtered_vcf/tbi` after scoring if this step is run. The file names for these outputs are then given by `VCF_ANNOTATE_SCORE_GENMOD:BCFTOOLS_VIEW`, i.e. with prefix `${meta.id}_genmod_score` as specified in the config file.
+- [#141](https://github.com/Clinical-Genomics/oncorefiner/pull/141) Refactored `GENERATE_CYTOSURE_FILES` to emit output from `VCF2CYTOSURE`.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#138](https://github.com/Clinical-Genomics/oncorefiner/pull/138) Changed indentation to consistently match the nf-core template.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/108) Updated `bcftools/view` module, also included in `genomic-medicine-sweden/vcf_annotate_score_genmod` subworkflow.
 - [#103](https://github.com/Clinical-Genomics/oncorefiner/pull/103) Changed `PROCESS_SNVS` output logic to return `ch_research_filtered_vcf/tbi` after scoring if this step is run. The file names for these outputs are then given by `VCF_ANNOTATE_SCORE_GENMOD:BCFTOOLS_VIEW`, i.e. with prefix `${meta.id}_genmod_score` as specified in the config file.
-- [#142](https://github.com/Clinical-Genomics/oncorefiner/pull/142) Update `pipelines_testdata_base_path` to reflect the latest commit to `Clinical-Genomics/test-datasets/oncorefiner` that adds LINX TSV files
+- [#142](https://github.com/Clinical-Genomics/oncorefiner/pull/142) Update `pipelines_testdata_base_path` to reflect the latest commit to `Clinical-Genomics/test-datasets/oncorefiner` that adds LINX TSV files.
 - [#141](https://github.com/Clinical-Genomics/oncorefiner/pull/141) Refactored `GENERATE_CYTOSURE_FILES` to emit output from `VCF2CYTOSURE`.
 
 ### `Fixed`

--- a/subworkflows/local/generate_cytosure_files/main.nf
+++ b/subworkflows/local/generate_cytosure_files/main.nf
@@ -37,4 +37,7 @@ workflow GENERATE_CYTOSURE_FILES {
         [[],[]],
         []
     )
+
+    emit:
+    VCF2CYTOSURE.out.cgh // channel: [val(meta), path(cgh)]
 }

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test
@@ -6,6 +6,8 @@ nextflow_workflow {
     tag "subworkflows"
     tag "generate_cytosure_files"
 
+    topics "versions"
+
     test("Alignment files from Tumor sample and somatic SV vcf files from TN test data") {
 
         when {
@@ -33,18 +35,11 @@ nextflow_workflow {
         }
 
         then {
-            // All directories and files in the output directory
-            def output_directories_and_files = getAllFilesFromDir(params.outdir, relative: true, includeDir: true)
-            // All files in the output directory
-            def output_files = getAllFilesFromDir(params.outdir)
-
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    // All directories and files in the output directory
-                    output_directories_and_files,
-                    // All files in the output directory with their md5 checksum
-                    output_files.collect { file -> [ file.getName(), path(file.toString()).md5 ] }
+                    topics,
+                    workflow.out
                 ).match() }
             )
         }
@@ -79,14 +74,11 @@ nextflow_workflow {
         }
 
         then {
-            // All directories and files in the output directory
-            def output_directories_and_files = getAllFilesFromDir(params.outdir, relative: true, includeDir: true)
-
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    // All directories and files in the output directory
-                    output_directories_and_files,
+                    topics,
+                    workflow.out
                 ).match() }
             )
         }

--- a/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_cytosure_files/tests/main.nf.test.snap
@@ -1,12 +1,37 @@
 {
     "Alignment files from Tumor sample and somatic SV vcf files from TN test data - stub": {
         "content": [
-            [
-                "vcf2cytosure",
-                "vcf2cytosure/tumor.cgh"
-            ]
+            {
+                "versions": [
+                    [
+                        "GENERATE_CYTOSURE_FILES:FILTER_VCF",
+                        "bcftools",
+                        "1.23.1"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:TIDDIT_COV",
+                        "tiddit",
+                        "3.9.5"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:VCF2CYTOSURE",
+                        "vcf2cytosure",
+                        "0.9.3"
+                    ]
+                ]
+            },
+            {
+                "0": [
+                    [
+                        {
+                            "id": "subject_a"
+                        },
+                        "tumor.cgh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-06-01T16:48:40.967945",
+        "timestamp": "2026-06-18T11:49:43.567602",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"
@@ -14,18 +39,37 @@
     },
     "Alignment files from Tumor sample and somatic SV vcf files from TN test data": {
         "content": [
-            [
-                "vcf2cytosure",
-                "vcf2cytosure/tumor.cgh"
-            ],
-            [
-                [
-                    "tumor.cgh",
-                    "09c4fba0b534f86fc176fe2ccf00820d"
+            {
+                "versions": [
+                    [
+                        "GENERATE_CYTOSURE_FILES:FILTER_VCF",
+                        "bcftools",
+                        "1.23.1"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:TIDDIT_COV",
+                        "tiddit",
+                        "3.9.5"
+                    ],
+                    [
+                        "GENERATE_CYTOSURE_FILES:VCF2CYTOSURE",
+                        "vcf2cytosure",
+                        "0.9.3"
+                    ]
                 ]
-            ]
+            },
+            {
+                "0": [
+                    [
+                        {
+                            "id": "subject_a"
+                        },
+                        "tumor.cgh:md5,09c4fba0b534f86fc176fe2ccf00820d"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-06-01T10:51:52.862763",
+        "timestamp": "2026-06-18T11:48:02.245565",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.2"


### PR DESCRIPTION
Part of: https://github.com/Clinical-Genomics/CancerBioInfo/issues/144

### Added

- `emit` statement so the subworkflow emits `VCF2CYTOSURE.out.cgh`.

### Changed

- Updated test to snapshot workflow output and versions, instead of published output directories and files as was previously done.
