### PR TITLE
chore: Migrate `prepare_references` to workflow outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,3 +128,4 @@ Initial release of Clinical-Genomics/oncorefiner, created with the [nf-core](htt
 - [#51](https://github.com/Clinical-Genomics/oncorefiner/pull/51) Removed unused parameter `custom_extra_files`.
 - [#125](https://github.com/Clinical-Genomics/oncorefiner/pull/125) Removed `input` parameter and samplesheet logic and documentation.
 - [#139](https://github.com/Clinical-Genomics/oncorefiner/pull/139) Removed SVDB output file, since it's an intermediary file not useful to have in the outputs.
+- [#152](https://github.com/Clinical-Genomics/oncorefiner/pull/152) Removed publishDir directive for `PREPARE_REFERENCES`.

--- a/conf/subworkflows/prepare_references.config
+++ b/conf/subworkflows/prepare_references.config
@@ -17,12 +17,6 @@
 
 process {
 
-    withName: '.*:PREPARE_REFERENCES:.*' {
-        publishDir = [
-            enabled: false,
-        ]
-    }
-
     withName: '.*PREPARE_REFERENCES:UNTAR_VEP_CACHE' {
         ext.when = { (params.vep_cache && params.vep_cache.endsWith("tar.gz")) }
     }


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/MTP-oncoflow/issues/83.

### Removed

- Removed publishDir directive for `PREPARE_REFERENCES`
